### PR TITLE
Added query options and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+TaskCluster API Utilities
+=========================
+
+Simple abstractions over `express` for declaring APIs with reference formats
+that enables automatic documentation and client libraries.
+
+**Quick example**
+```js
+let API = require('taskcluster-lib-api');
+
+// First declare an API
+let api = new API({
+  // Title and description for docs
+  title: 'My API',
+  description: [
+    "Long string with **markdown** support, used for writing docs",
+    "typically written using [].join('\n') to allow for long strings"
+  ].join('\n'),
+
+  // Patterns for common URL parameters
+  params: {
+    userId: /^[a-z0-9]+$/
+  },
+
+  // Prefix for all schema referenced
+  schemaPrefix: 'http://myschema-site.com/folder/',
+
+  // List of properties required as context in api.router(...)
+  // provided as `this` context to handlers
+  context: ['myDataStore']
+});
+
+// Now declare an API method (see code docs for additional options)
+api.declare({
+  method: 'get',
+  route:  '/:userId',
+  name:   'getUser',
+  output: 'my-user-schema.json',
+  title:  "Get a user",
+  description: "Long description... in **markdown**..."
+}, async function(req, res) {
+  let user = await this.myDataStore.find(req.params.userId);
+  res.reply({
+    data: "in compliance with schema",
+  });
+});
+
+
+// Now create an express router
+let router = api.setup({
+  context: {
+    myDataStore:      new DataStore(),
+  },
+  validator:          new base.validator(),
+});
+
+// Add to express app
+app.use(router);
+```
+
+### Documentation from `API.declare`
+You may also find this in the code, which the canonical documentation.
+
+```js
+/**
+ * Declare an API end-point entry, where options is on the following form:
+ *
+ * {
+ *   method:   'post|head|put|get|delete',
+ *   route:    '/object/:id/action/:param',      // URL pattern with parameters
+ *   params: {                                   // Patterns for URL params
+ *     param: /.../,                             // Reg-exp pattern
+ *     id(val) { return "..." }                  // Function, returns message
+ *                                               // if value is invalid
+ *     // The `params` option from new API(), will be used as fall-back
+ *   },
+ *   query: {                                    // Query-string parameters
+ *     offset: /.../,                            // Reg-exp pattern
+ *     limit(n) { return "..." }                 // Function, returns message
+ *                                               // if value is invalid
+ *     // Query-string options are always optional (at-least in this iteration)
+ *   },
+ *   name:     'identifierForLibraries',         // identifier for client libraries
+ *   stability: base.API.stability.experimental, // API stability level
+ *   scopes:   ['admin', 'superuser'],           // Scopes for the request
+ *   scopes:   [['admin'], ['per1', 'per2']],    // Scopes in disjunctive form
+ *                                               // admin OR (per1 AND per2)
+ *   input:    'input-schema.json',              // optional, null if no input
+ *   output:   'output-schema.json',             // optional, null if no output
+ *   skipInputValidation:    true,               // defaults to false
+ *   skipOutputValidation:   true,               // defaults to false
+ *   title:     "My API Method",
+ *   description: [
+ *     "Description of method in markdown, enjoy"
+ *   ].join('\n')
+ * }
+ *
+ * The handler parameter is a normal connect/express request handler, it should
+ * return JSON replies with `request.reply(json)` and errors with
+ * `request.json(code, json)`, as `request.reply` may be validated against the
+ * declared output schema.
+ *
+ * **Note** the handler may return a promise, if this promise fails we will
+ * log the error and return an error message. If the promise is successful,
+ * nothing happens.
+ */
+```

--- a/src/api.js
+++ b/src/api.js
@@ -138,6 +138,54 @@ var schema = function(validator, options) {
   };
 };
 
+
+/**
+ * Validate query-string against query.
+ *
+ * options:
+ * {
+ *   param1: /.../,               // Reg-exp pattern
+ *   param2(val) { return "..." } // Function, returns message if invalid
+ * }
+ *
+ * Query-string options not specified in options will not be allowed. But it's
+ * optional if a request carries any query-string parameters at all.
+ */
+var queryValidator = function(options = {}) {
+  return function(req, res, next) {
+    let errors = [];
+    _.forEach(req.query || {}, (value, key) => {
+      let pattern = options[key];
+      if (!pattern) {
+        // Allow the bewit key, it's used in signed strings
+        if (key === 'bewit') {
+          return;
+        }
+        // Unsupported option
+        errors.push('Query-string parameter: ' + key + ' is not supported!');
+      }
+      if (pattern instanceof RegExp) {
+        if (!pattern.test(value)) {
+          errors.push('Query-string parameter: ' + key + '="' + value +
+                      '" does not match expression: ' + pattern.toString());
+        }
+      } else {
+        let msg = pattern(value);
+        if (typeof(msg) === 'string') {
+          errors.push('Query-string parameter: ' + key + '="' + value +
+                      '" is not valid, error: ' + msg);
+        }
+      }
+    });
+    if (errors.length > 0) {
+      return res.status(400).json({
+        message: errors.join('\n'),
+      });
+    }
+    return next();
+  };
+};
+
 /**
  * Abstraction of a client with some helper methods
  *
@@ -1254,8 +1302,8 @@ var API = function(options) {
   });
   this._options = _.defaults({}, options, {
     schemaPrefix:   '',
-    paramPatterns:  {},
-    context:        []
+    params:         {},
+    context:        [],
   });
   this._entries = [];
 };
@@ -1310,8 +1358,15 @@ var STABILITY_LEVELS = _.values(stability);
  *   route:    '/object/:id/action/:param',      // URL pattern with parameters
  *   params: {                                   // Patterns for URL params
  *     param: /.../,                             // Reg-exp pattern
- *     id(val) { return "..." }                  // Function, returns message if invalid
+ *     id(val) { return "..." }                  // Function, returns message
+ *                                               // if value is invalid
  *     // The `params` option from new API(), will be used as fall-back
+ *   },
+ *   query: {                                    // Query-string parameters
+ *     offset: /.../,                            // Reg-exp pattern
+ *     limit(n) { return "..." }                 // Function, returns message
+ *                                               // if value is invalid
+ *     // Query-string options are always optional (at-least in this iteration)
  *   },
  *   name:     'identifierForLibraries',         // identifier for client libraries
  *   stability: base.API.stability.experimental, // API stability level
@@ -1349,6 +1404,12 @@ API.prototype.declare = function(options, handler) {
          "options.stability must be a valid stability-level, " +
          "see base.API.stability for valid options");
   options.params = _.defaults({}, options.params || {}, this._options.params);
+  options.query = options.query || {};
+  _.forEach(options.query, (value, key) => {
+    if (!(value instanceof RegExp || value instanceof Function)) {
+      throw new Error('query.' + key + ' must be a RegExp or a function!');
+    }
+  });
   if ('scopes' in options) {
     utils.validateScopeSets(options.scopes);
   }
@@ -1518,6 +1579,7 @@ API.prototype.router = function(options) {
     middleware.push(
       authStrategy(entry),
       parameterValidator(entry.params),
+      queryValidator(entry.query),
       schema(options.validator, entry),
       handle(entry.handler, options.context)
     );
@@ -1565,6 +1627,7 @@ API.prototype.reference = function(options) {
         type:           'function',
         method:         entry.method,
         route:          route,
+        query:          _.keys(entry.query || {}),
         args:           params,
         name:           entry.name,
         stability:      entry.stability,

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -7,7 +7,7 @@
   "properties": {
     "version": {
       "description":          "API reference version",
-      "enum":                 [0, "0.2.0"]
+      "enum":                 [0]
     },
     "$schema": {
       "description":          "Link to schema for this reference. That is a link to this very document. Typically used to identify what kind of reference this file is.",
@@ -62,6 +62,14 @@
               "description":  "Argument that appears in `route` warpped in angle brackets. It must be replaced to call the function."
             }
           },
+          "query": {
+            "type":           "array",
+            "description":    "List of accepted query-string parameters, these are always optional.",
+            "items": {
+              "type":         "string",
+              "description":  "Optional query-string parameter"
+            }
+          },
           "name": {
             "type":           "string",
             "description":    "Name of the `function` this is a stable identifier for use in auto-generated client libraries"
@@ -110,7 +118,7 @@
         },
         "additionalProperties":   false,
         "required": [
-          "type", "method", "route", "args",
+          "type", "method", "route", "args", "query",
           "name", "stability", "title", "description"
         ]
       }

--- a/test/api/context_test.js
+++ b/test/api/context_test.js
@@ -8,7 +8,7 @@ suite("API (context)", function() {
 
   test("Provides context", function() {
     // Create test api
-    var api = new base.API({
+    var api = new subject({
       title:        "Test Api",
       description:  "Another test api"
     });
@@ -61,7 +61,7 @@ suite("API (context)", function() {
 
   test("Context properties can be required", function() {
     // Create test api
-    var api = new base.API({
+    var api = new subject({
       title:        "Test Api",
       description:  "Another test api",
       context:      ['prop1', 'prop2']
@@ -85,7 +85,7 @@ suite("API (context)", function() {
 
   test("Context properties can provided", function() {
     // Create test api
-    var api = new base.API({
+    var api = new subject({
       title:        "Test Api",
       description:  "Another test api",
       context:      ['prop1', 'prop2']

--- a/test/api/route_test.js
+++ b/test/api/route_test.js
@@ -10,7 +10,7 @@ suite("api/route", function() {
   var slugid          = require('slugid');
 
   // Create test api
-  var api = new base.API({
+  var api = new subject({
     title:        "Test Api",
     description:  "Another test api",
     params: {
@@ -26,6 +26,19 @@ suite("api/route", function() {
     description:  "Place we can call to test something",
   }, function(req, res) {
     res.status(200).send(req.params.myparam);
+  });
+
+  api.declare({
+    method:   'get',
+    route:    '/query-param/',
+    query: {
+      nextPage: /^[0-9]+$/,
+    },
+    name:     'testQueryParam',
+    title:    "Test End-Point",
+    description:  "Place we can call to test something",
+  }, function(req, res) {
+    res.status(200).send(req.query.nextPage || 'empty');
   });
 
   api.declare({
@@ -143,6 +156,40 @@ suite("api/route", function() {
       });
   });
 
+  test("query parameter", function() {
+    var url = 'http://localhost:23525/query-param/';
+    return request
+      .get(url)
+      .query({nextPage: '352'})
+      .end()
+      .then(function(res) {
+        assert(res.ok, "Request failed");
+        assert(res.text === "352", "Got wrong value");
+      });
+  });
+
+  test("query parameter (is optional)", function() {
+    var url = 'http://localhost:23525/query-param/';
+    return request
+      .get(url)
+      .end()
+      .then(function(res) {
+        assert(res.ok, "Request failed");
+        assert(res.text === "empty", "Got wrong value");
+      });
+  });
+
+  test("query parameter (validation works)", function() {
+    var url = 'http://localhost:23525/query-param/';
+    return request
+      .get(url)
+      .query({nextPage: 'abc'})
+      .end()
+      .then(function(res) {
+        assert(!res.ok, "Expected request failure!");
+        assert(res.status === 400, "Expected a 400 error");
+      });
+  });
 
   test("slash parameter", function() {
     var url = 'http://localhost:23525/slash-param/Hello/World';


### PR DESCRIPTION
@jhford, please give this a review...

@petemoore, this affects golang client, well in the future (it's fully backwards compatible). So if you want to have a look feel free, now is the time to change anything in what query string do.


--------
Basically, this adds support for defining query-string parameters. These query-string parameters are always optional, but you can't send a query-string parameter that isn't supported.

I really don't see any use-case for query-string for `continuationToken` when paging through a long list of items (tasks, index entries, etc). Notice that we can't send the `continuationToken` as payload on a get request. As this is the only use I have for now, I went for a very simple implementation.

So query-string parameters here is really just options... Think of it as an optional payload.

Generally, we'll use payload for everything, but in cases where you want to query something, maybe query string is useful. We could also specify querystring using JSON schema, but it just seems overkill, anyways, I think we can add such support later if we really want that power.