### PR TITLE
Removed property 'query' from requiredProperties

### DIFF
--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -118,7 +118,7 @@
         },
         "additionalProperties":   false,
         "required": [
-          "type", "method", "route", "args", "query",
+          "type", "method", "route", "args",
           "name", "stability", "title", "description"
         ]
       }


### PR DESCRIPTION
For API references, `query` is an optional property, only required when
an API endpoint accepts querystring parameters. Most of our API
endpoints do not accept querystring parameters, and most endpoints
currently do not include it in their definition.  However, currently it
is listed as a required property, which means our references are now not
conformant with the schema. This commit removes `query` from the
requiredProperties list so that it can be omitted in the majority of
cases where it is not needed, and fixes the references to be compliant
with the schema again, as currently most are invalid.