### PR TITLE
Use hasOwnProperty, and JSON.stringify non-strings

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -49,8 +49,8 @@ let BuildReportErrorMethod = (method, errorCodes, raven = null) => {
         time:    (new Date()).toJSON(),
       };
       message = message.replace(/{{([a-zA-Z0-9_-]+)}}/g, (text, key) => {
-        let value = details[key] || text;
-        if (typeof(value) === 'string') {
+        let value = details.hasOwnProperty(key) ? details[key] : text;
+        if (typeof(value) !== 'string') {
           return JSON.stringify(value, null, 2);
         }
         return value;


### PR DESCRIPTION
@imbstack, let me know if you think this is sane...

I suspect it was a bug in the original code.

Oh, if you like let's bump version and bump it in tc-base too.. So we can get this everywhere...