### PR TITLE
Authentication failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-api",
-  "version": "0.10.3",
+  "version": "0.10.5",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "taskcluster-lib-api",
   "license": "MPL-2.0",

--- a/src/api.js
+++ b/src/api.js
@@ -431,7 +431,7 @@ var remoteAuthentication = function(options, entry) {
         // If authentication failed
         if (result.status === 'auth-failed') {
           if (!noReply) {
-            res.reportError('AuthorizationFailed', result.message, result);
+            res.reportError('AuthenticationFailed', result.message, result);
           }
           return false;
         }

--- a/src/api.js
+++ b/src/api.js
@@ -431,6 +431,7 @@ var remoteAuthentication = function(options, entry) {
         // If authentication failed
         if (result.status === 'auth-failed') {
           if (!noReply) {
+            res.set('www-authenticate', 'hawk');
             res.reportError('AuthenticationFailed', result.message, result);
           }
           return false;

--- a/src/errors.js
+++ b/src/errors.js
@@ -5,7 +5,7 @@ const ERROR_CODES = {
   MalformedPayload:         400,  // Only for JSON.parse() errors
   InvalidRequestArguments:  400,  // Only for query and param validation errors
   InputValidationError:     400,  // Only for JSON schema errors
-  AuthorizationFailed:      401,  // Only if authentication failed
+  AuthenticationFailed:     401,  // Only if authentication failed
   InsufficientScopes:       403,  // Only if request had insufficient scopes
   ResourceNotFound:         404,  // If the resource wasn't found
   RequestConflict:          409,  // If the request conflicts with server state


### PR DESCRIPTION
@djmitche and @imbstack, do you agree...

I've already made some unit tests that checks `err.code === 'AuthenticationFailed'`.
But I don't think we have too many... I suspect we should do this now, before it's too late.

I think authorization failure will always use the: `InsufficientScopes` error code.
And if that's not applicable, we should introduce: `AuthorizationFailed: 403`

Agree? (I always get this wrong so I better ask two people)