### PR TITLE
Use tc-lib-validate in place of schema-validator-publisher

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "taskcluster-client": "0.23.4",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
-    "taskcluster-lib-validate": "^0.4.2",
     "type-is": "^1.6.10",
     "uuid": "^2.0.1"
   },
@@ -54,6 +53,7 @@
     "taskcluster-lib-config": "^0.8.8",
     "taskcluster-lib-testing": "^0.10.1",
     "taskcluster-lib-app": "^0.8.9",
+    "taskcluster-lib-validate": "^0.4.2",
     "tc-rules": "^2.0.0"
   },
   "main": "./lib/api.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-api",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "taskcluster-lib-api",
   "license": "MPL-2.0",
@@ -15,6 +15,7 @@
     "url": "https://github.com/taskcluster/taskcluster-lib-api.git"
   },
   "dependencies": {
+    "ajv": "^3.8.5",
     "aws-sdk": "^2.1.21",
     "aws-sdk-promise": "0.0.2",
     "babel-runtime": "^6.3.19",
@@ -25,7 +26,6 @@
     "hawk": "2.3.0",
     "lodash": "2.4.1",
     "promise": "^7.0.4",
-    "schema-validator-publisher": "^0.8.8",
     "slugid": "^1.1.0",
     "source-map-support": "^0.3.3",
     "superagent": "0.18.2",
@@ -34,7 +34,7 @@
     "taskcluster-client": "0.23.4",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
-    "taskcluster-lib-testing": "^0.10.1",
+    "taskcluster-lib-validate": "^0.4.2",
     "type-is": "^1.6.10",
     "uuid": "^2.0.1"
   },
@@ -52,7 +52,7 @@
     "eslint": "^1.9.0",
     "mocha": "2.0.1",
     "taskcluster-lib-config": "^0.8.8",
-    "taskcluster-lib-testing": "^0.8.10",
+    "taskcluster-lib-testing": "^0.10.1",
     "taskcluster-lib-app": "^0.8.9",
     "tc-rules": "^2.0.0"
   },

--- a/src/api.js
+++ b/src/api.js
@@ -20,7 +20,8 @@ var crypto        = require('crypto');
 var series        = require('taskcluster-lib-stats/lib/series');
 var cryptiles     = require('cryptiles');
 var taskcluster   = require('taskcluster-client');
-var Validator     = require('schema-validator-publisher').Validator;
+var validator     = require('taskcluster-lib-validate');
+var Ajv           = require('ajv');
 var errors        = require('./errors');
 var typeis        = require('type-is');
 
@@ -99,7 +100,7 @@ var parameterValidator = function(options) {
  * Handlers may output errors using `req.json`, as `req.reply` will validate
  * against schema and always returns a 200 OK reply.
  */
-var schema = function(validator, options) {
+var schema = function(validate, options) {
   return function(req, res, next) {
     // If input schema is defined we need to validate the input
     if (options.input !== undefined && !options.skipInputValidation) {
@@ -111,15 +112,15 @@ var schema = function(validator, options) {
           contentType: (req.headers['content-type'] || null),
         });
       }
-      var errors = validator.check(req.body, options.input);
-      if (errors) {
+      var error = validate(req.body, options.input);
+      if (error) {
         debug("Request payload for %s didn't follow schema %s",
               req.url, options.input);
         return res.reportError(
           'InputValidationError',
           "Request payload must follow the schema: {{schema}}\n" +
-          "Errors: {{errors}}", {
-          errors,
+          "Error: {{error}}", {
+          error,
           schema: options.input,
           payload: req.body
         });
@@ -131,14 +132,14 @@ var schema = function(validator, options) {
       // If we're supposed to validate outgoing messages and output schema is
       // defined, then we have to validate against it...
       if(options.output !== undefined && !options.skipOutputValidation) {
-        var errors = validator.check(json, options.output);
-        if (errors) {
+        var error = validate(json, options.output);
+        if (error) {
           debug("Reply for %s didn't match schema: %s got errors: %j from output: %j",
-                req.url, options.output, errors, json);
+                req.url, options.output, error, json);
           let err = new Error('Output schema validation of ' + options.output);
           err.schema = options.output;
           err.url = req.url;
-          err.errors = errors;
+          err.errors = [error,];
           err.payload = json;
           return res.reportInternalError(err);
         }
@@ -679,17 +680,7 @@ API.prototype.declare = function(options, handler) {
  * Return an `express.Router` instance.
  */
 API.prototype.router = function(options) {
-  //assert(options.validator instanceof Validator,
-  //       "API.router() needs a validator");
-  // NOTE that instanceof Validator and similar calls will no longer work
-  // in the split-tc-base world.
-  assert(options.validator.constructor.name === 'Validator');
-  debugger;
-  ['check', 'load', 'register'].forEach(function(x) {
-    assert(typeof options.validator.constructor.prototype[x] === 'function',
-        'API.router() needs validator property with ' + x + ' function');
-  });
-
+  assert(options.validator);
 
   // Provide default options
   options = _.defaults({}, options, {
@@ -870,21 +861,19 @@ API.prototype.reference = function(options) {
     })
   };
 
-  // Create validator to validate schema
-  var validator = new Validator();
-  // Load api-reference.json schema from disk
+  var ajv = Ajv({useDefaults: 'clone', format: 'full', verbose: true, allErrors: true});
   var schemaPath = path.join(__dirname, 'schemas', 'api-reference.json');
   var schema = fs.readFileSync(schemaPath, {encoding: 'utf-8'});
-  validator.register(JSON.parse(schema));
+  var validate = ajv.compile(JSON.parse(schema));
 
   // Check against it
   var refSchema = 'http://schemas.taskcluster.net/base/v1/api-reference.json#';
-  var errors = validator.check(reference, refSchema);
-  if (errors) {
+  var valid = validate(reference, refSchema);
+  if (!valid) {
     debug("API.references(): Failed to validate against schema, errors: %j " +
-          "reference: %j", errors, reference);
+          "reference: %j", validate.errors, reference);
     debug("Reference:\n%s", JSON.stringify(reference, null, 2));
-    debug("Errors:\n%s", JSON.stringify(errors, null, 2));
+    debug("Errors:\n%s", JSON.stringify(validate.errors, null, 2));
     throw new Error("API.references(): Failed to validate against schema");
   }
 

--- a/src/api.js
+++ b/src/api.js
@@ -20,7 +20,6 @@ var crypto        = require('crypto');
 var series        = require('taskcluster-lib-stats/lib/series');
 var cryptiles     = require('cryptiles');
 var taskcluster   = require('taskcluster-client');
-var validator     = require('taskcluster-lib-validate');
 var Ajv           = require('ajv');
 var errors        = require('./errors');
 var typeis        = require('type-is');
@@ -114,13 +113,11 @@ var schema = function(validate, options) {
       }
       var error = validate(req.body, options.input);
       if (error) {
-        debug("Request payload for %s didn't follow schema %s",
-              req.url, options.input);
+        debug('Input schema validation error: ' + error);
         return res.reportError(
           'InputValidationError',
-          "Request payload must follow the schema: {{schema}}\n" +
-          "Error: {{error}}", {
           error,
+        {
           schema: options.input,
           payload: req.body
         });
@@ -134,12 +131,10 @@ var schema = function(validate, options) {
       if(options.output !== undefined && !options.skipOutputValidation) {
         var error = validate(json, options.output);
         if (error) {
-          debug("Reply for %s didn't match schema: %s got errors: %j from output: %j",
-                req.url, options.output, error, json);
-          let err = new Error('Output schema validation of ' + options.output);
+          debug('Output schema validation error: ' + error);
+          let err = new Error('Output schema validation error: ' + error);
           err.schema = options.output;
           err.url = req.url;
-          err.errors = [error,];
           err.payload = json;
           return res.reportInternalError(err);
         }

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -5,7 +5,7 @@ suite("api/auth", function() {
   var Promise         = require('promise');
   var testing         = require('taskcluster-lib-testing');
   var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var makeApp         = require('taskcluster-lib-app');
   var subject         = require('../');
   var express         = require('express');
@@ -13,6 +13,7 @@ suite("api/auth", function() {
   var slugid          = require('slugid');
   var crypto          = require('crypto');
   var testing         = require('taskcluster-lib-testing');
+  var path            = require('path');
 
   // Reference for test api server
   var _apiServer = null;
@@ -102,7 +103,10 @@ suite("api/auth", function() {
 
     // Create router
     var router = api.router({
-      validator:      await makeValidator(),
+      validator:      await validator({
+        folder:         path.join(__dirname, 'schemas'),
+        baseUrl:        'http://localhost:4321/'
+      }),
     });
 
     // Create application

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -1,11 +1,12 @@
 suite("API (context)", function() {
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var makeApp         = require('taskcluster-lib-app');
   var subject         = require('../');
   var assert          = require('assert');
   var Promise         = require('promise');
   var request         = require('superagent-promise');
   var slugid          = require('slugid');
+  var path            = require('path');
 
   test("Provides context", async () => {
     // Create test api
@@ -25,9 +26,12 @@ suite("API (context)", function() {
     });
 
     var value = slugid.v4();
-    let validator = await makeValidator();
+    let validate = await validator({
+      folder:         path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/'
+    });
     var router = api.router({
-      validator:  validator,
+      validator:  validate,
       context: {
         myProp: value
       }
@@ -67,10 +71,13 @@ suite("API (context)", function() {
     });
 
     var value = slugid.v4();
-    let validator = await makeValidator()
+    let validate = await validator({
+      folder:         path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/'
+    });
     try {
       api.router({
-        validator:  validator,
+        validator:  validate,
         context: {
           prop1: "value1"
         }
@@ -90,9 +97,12 @@ suite("API (context)", function() {
     });
 
     var value = slugid.v4();
-    let validator = await makeValidator();
+    let validate = await validator({
+      folder:         path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/'
+    });
     api.router({
-      validator:  validator,
+      validator:  validate,
       context: {
         prop1: "value1",
         prop2: "value2"

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -7,7 +7,7 @@ suite("api/responsetimer", function() {
   var subject         = require('../');
   var stats           = require('taskcluster-lib-stats');
   var config          = require('taskcluster-lib-config');
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var express         = require('express');
   var path            = require('path');
 
@@ -67,7 +67,10 @@ suite("api/responsetimer", function() {
       _mockAuthServer = server;
     }).then(function() {
       // Create server for api
-      return makeValidator().then(function(validator) {
+      return validator({
+        folder:         path.join(__dirname, 'schemas'),
+        baseUrl:        'http://localhost:4321/'
+      }).then(function(validator) {
         influx = new stats.Influx({
           connectionString:   cfg.get('influxdb:connectionString')
         });

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -4,10 +4,11 @@ suite("api/route", function() {
   var assert          = require('assert');
   var Promise         = require('promise');
   var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var subject         = require('../');
   var express         = require('express');
   var slugid          = require('slugid');
+  var path            = require('path');
 
   // Create test api
   var api = new subject({
@@ -93,7 +94,10 @@ suite("api/route", function() {
       _mockAuthServer = server;
     }).then(function() {
       // Create server for api
-      return makeValidator().then(function(validator) {
+      return validator({
+        folder: path.join(__dirname, 'schemas'),
+        baseUrl:        'http://localhost:4321/',
+      }).then(function(validator) {
 
         // Create router
         var router = api.router({

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -4,7 +4,7 @@ suite("api/schemaPrefix", function() {
   var assert          = require('assert');
   var Promise         = require('promise');
   var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var subject         = require('../');
   var express         = require('express');
   var path            = require('path');
@@ -55,9 +55,9 @@ suite("api/schemaPrefix", function() {
       _mockAuthServer = server;
     }).then(function() {
       // Create validator
-      var validatorCreated = makeValidator({
+      var validatorCreated = validator({
         folder:         path.join(__dirname, 'schemas'),
-        schemaBaseUrl:  'http://localhost:4321/'
+        baseUrl:        'http://localhost:4321/'
       });
 
       // Create server for api

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -4,7 +4,7 @@ suite("api/validate", function() {
   var assert          = require('assert');
   var Promise         = require('promise');
   var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
-  var makeValidator   = require('schema-validator-publisher');
+  var validator       = require('taskcluster-lib-validate');
   var subject         = require('../');
   var express         = require('express');
   var path            = require('path');
@@ -93,9 +93,9 @@ suite("api/validate", function() {
       _mockAuthServer = server;
     }).then(function() {
       // Create validator
-      var validatorCreated = makeValidator({
+      var validatorCreated = validator({
         folder:         path.join(__dirname, 'schemas'),
-        schemaBaseUrl:  'http://localhost:4321/'
+        baseUrl:        'http://localhost:4321/'
       });
 
       // Create server for api


### PR DESCRIPTION
This is an api breaking change, but introduces some nice errors in place of the opaque ones that the old library had.