### PR TITLE
Add tc-lib-monitor for stats and error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "superagent-hawk": "0.0.4",
     "superagent-promise": "0.1.2",
     "taskcluster-client": "0.23.4",
-    "taskcluster-lib-monitor": "^0.3.0",
     "taskcluster-lib-scopes": "^0.8.8",
-    "taskcluster-lib-stats": "^0.8.7",
     "type-is": "^1.6.10",
     "uuid": "^2.0.1"
   },
@@ -54,6 +52,7 @@
     "taskcluster-lib-config": "^0.8.8",
     "taskcluster-lib-testing": "^0.10.1",
     "taskcluster-lib-app": "^0.8.9",
+    "taskcluster-lib-monitor": "^0.3.0",
     "taskcluster-lib-validate": "^0.4.2",
     "tc-rules": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "superagent-hawk": "0.0.4",
     "superagent-promise": "0.1.2",
     "taskcluster-client": "0.23.4",
+    "taskcluster-lib-monitor": "^0.3.0",
     "taskcluster-lib-scopes": "^0.8.8",
     "taskcluster-lib-stats": "^0.8.7",
     "type-is": "^1.6.10",

--- a/src/api.js
+++ b/src/api.js
@@ -794,7 +794,7 @@ API.prototype.router = function(options) {
     // Add authentication, schema validation and handler
     middleware.push(
       errors.BuildReportErrorMethod(
-        entry.name, this._options.errorCodes, options.raven
+        entry.name, this._options.errorCodes, (monitor || options.raven)
       ),
       bodyParser.text({
         limit:          options.inputLimit,

--- a/src/monitoring.js
+++ b/src/monitoring.js
@@ -1,0 +1,45 @@
+let debug = require('debug')('base:api');
+
+/**
+ * Middleware that reports timings to Statsum.
+ *
+ * The `method` is the name of the API method, `monitor` is an instance of
+ * taskcluster-lib-monitor.
+ */
+let createReporter = (method, monitor) => {
+  return (req, res, next) => {
+    let sent = false;
+    let start = process.hrtime();
+    let send = () => {
+      try {
+        // Avoid sending twice
+        if (sent) {
+          return;
+        }
+        sent = true;
+
+        let d = process.hrtime(start);
+
+        let success = 'success';
+        if (res.statusCode >= 500) {
+          success = 'server-error';
+        } else if (res.statusCode >= 400) {
+          success = 'client-error';
+        }
+
+        for (let stat of [success, 'all']) {
+          let k = [method, stat].join('.');
+          monitor.measure(k, d[0] * 1000 + (d[1] / 1000000));
+          monitor.count(k);
+        }
+      } catch (e) {
+        debug("Error while compiling response times: %s, %j", err, err, err.stack);
+      }
+    };
+    res.once('finish', send);
+    res.once('close', send);
+    next();
+  };
+}
+
+exports.createReporter = createReporter;

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -5,26 +5,10 @@ suite("api/responsetimer", function() {
   var Promise         = require('promise');
   var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
   var subject         = require('../');
-  var stats           = require('taskcluster-lib-stats');
-  var config          = require('taskcluster-lib-config');
   var monitoring      = require('taskcluster-lib-monitor');
   var validator       = require('taskcluster-lib-validate');
   var express         = require('express');
   var path            = require('path');
-
-  // Load necessary configuration
-  var cfg = config({
-    envs: [
-      'influxdb_connectionString',
-    ],
-    filename:               'taskcluster-base-test'
-  });
-
-  if (!cfg.get('influxdb:connectionString')) {
-    throw new Error("Skipping 'ResponseTimerTest', missing config file: " +
-                    "taskcluster-base-test.conf.json");
-    return;
-  }
 
   // Create test api
   var api = new subject({
@@ -49,7 +33,17 @@ suite("api/responsetimer", function() {
     title:    "Test End-Point",
     description:  "Place we can call to test something",
   }, function(req, res) {
-    res.status(200).send(req.params.name);
+    res.status(404).send(req.params.name);
+  });
+
+  api.declare({
+    method:   'get',
+    route:    '/another-param/:name(*)',
+    name:     'testAnotherParam',
+    title:    "Test End-Point",
+    description:  "Place we can call to test something",
+  }, function(req, res) {
+    res.status(500).send(req.params.name);
   });
 
   // Reference to mock authentication server
@@ -57,7 +51,6 @@ suite("api/responsetimer", function() {
   // Reference for test api server
   var _apiServer = null;
 
-  var influx = null;
   var monitor = null;
 
   setup(function(){
@@ -73,9 +66,6 @@ suite("api/responsetimer", function() {
         folder:         path.join(__dirname, 'schemas'),
         baseUrl:        'http://localhost:4321/'
       }).then(async function(validator) {
-        influx = new stats.Influx({
-          connectionString:   cfg.get('influxdb:connectionString'),
-        });
         monitor = await monitoring({
           project: 'tc-lib-api-test',
           credentials: {clientId: 'fake', accessToken: 'fake'},
@@ -86,8 +76,6 @@ suite("api/responsetimer", function() {
         var router = api.router({
           validator:      validator,
           authBaseUrl:    'http://localhost:23243',
-          component:      'ResponseTimerTest',
-          drain:           influx,
           monitor,
         });
 
@@ -131,22 +119,27 @@ suite("api/responsetimer", function() {
   });
 
   test("single parameter", function() {
-    var url = 'http://localhost:23525/single-param/Hello';
-    return request
-      .get(url)
-      .end()
-      .then(function(res) {
-        assert(influx.pendingPoints() === 1, "Expected just one point");
-        return influx.flush();
-      }).then(function() {
-        assert(influx.pendingPoints() === 0, "Expected points to be cleared");
-        assert.equal(Object.keys(monitor.counts).length, 2);
-        assert.equal(monitor.counts['tc-lib-api-test.ResponseTimerTest.api.testParam.200'], 1);
-        assert.equal(monitor.counts['tc-lib-api-test.ResponseTimerTest.api.testParam.all'], 1);
+    return Promise.all([
+        request.get('http://localhost:23525/single-param/Hello').end(),
+        request.get('http://localhost:23525/single-param/Goodbye').end(),
+        request.get('http://localhost:23525/slash-param/Slash').end(),
+        request.get('http://localhost:23525/another-param/Another').end(),
+      ]).then(function() {
+        assert.equal(Object.keys(monitor.counts).length, 6);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testParam.success'], 2);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testParam.all'], 2);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testSlashParam.client-error'], 1);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testSlashParam.all'], 1);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testAnotherParam.server-error'], 1);
+        assert.equal(monitor.counts['tc-lib-api-test.api.testAnotherParam.all'], 1);
 
-        assert.equal(Object.keys(monitor.measures).length, 2);
-        assert(monitor.measures['tc-lib-api-test.ResponseTimerTest.api.testParam.200'] > 0.0);
-        assert(monitor.measures['tc-lib-api-test.ResponseTimerTest.api.testParam.all'] > 0.0);
+        assert.equal(Object.keys(monitor.measures).length, 6);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testParam.success'].length, 2);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testParam.all'].length, 2);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testSlashParam.client-error'].length, 1);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testSlashParam.all'].length, 1);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testAnotherParam.server-error'].length, 1);
+        assert.equal(monitor.measures['tc-lib-api-test.api.testAnotherParam.all'].length, 1);
       });
   });
 });


### PR DESCRIPTION
This adds tc-lib-monitor for monitoring and error reporting while still allowing tc-lib-stats to be used for backwards-compatibility and enable an easy upgrade path. Eventually we can remove tc-lib-stats.