### PR TITLE
Use `req.params` by default when deferAuth is false

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -316,6 +316,8 @@ var createRemoteSignatureValidator = function(options) {
  * Note that `deferAuth` will not perform authorization unless, `req.satisfies({})`
  * is called either without arguments or with an object as first argument.
  *
+ * If `deferAuth` is false, then req.params will be used as the scope parameters.
+ *
  * The `req.scopes()` method returns a Promise for the set of scopes the caller
  * has. Please, note that `req.scopes()` returns `[]` if there was an
  * authentication error.
@@ -472,8 +474,9 @@ var remoteAuthentication = function(options, entry) {
         return retval;
       };
 
-      // If authentication is deferred or satisfied, then we proceed
-      if (!entry.scopes || entry.deferAuth || req.satisfies(entry.scopes)) {
+      // If authentication is deferred or satisfied, then we proceed,
+      // substituting the request paramters by default
+      if (!entry.scopes || entry.deferAuth || req.satisfies(req.params)) {
         next();
       }
     }).catch(function(err) {


### PR DESCRIPTION
[Bug 1290549](https://bugzilla.mozilla.org/show_bug.cgi?id=1290549)
identifies at least one place where this is assumed to be the case, and
there are probably more.