### PR TITLE
Remove mockauthserver import from lib-testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "source-map-support": "^0.4.2",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
     "eslint": "^1.9.0",
     "mocha": "2.0.1",
-    "taskcluster-lib-config": "^0.8.8",
-    "taskcluster-lib-testing": "^0.10.0",
+    "source-map-support": "^0.4.2",
     "taskcluster-lib-app": "^0.8.9",
+    "taskcluster-lib-config": "^0.8.8",
     "taskcluster-lib-monitor": "^1.0.1",
+    "taskcluster-lib-testing": "^1.0.3",
     "taskcluster-lib-validate": "^0.4.2"
   },
   "main": "./lib/api.js"

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -4,58 +4,6 @@ suite("api/publish", function() {
   var aws             = require('aws-sdk');
   var assert          = require('assert');
   var Promise         = require('promise');
-  var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
-
-  // Sanity checks for the reference
-  test("reference from mockAuthServer", function() {
-    var reference = mockAuthServer.api.reference({
-      baseUrl:          'http://localhost:23243/v1'
-    });
-    assert(reference.entries, "Missing entries");
-    assert(reference.entries.length > 0, "Has no entries");
-    assert(reference.title, "Missing title");
-  });
-
-  // Test publish reference from mockAuthServer
-  test("publish reference from mockAuthServer", function() {
-    var cfg = config({
-      envs: [
-        'aws_accessKeyId',
-        'aws_secretAccessKey',
-        'aws_region',
-        'aws_apiVersion',
-        'referenceTestBucket'
-      ],
-      filename:               'taskcluster-base-test'
-    });
-
-    if (!cfg.get('aws') || !cfg.get('referenceTestBucket')) {
-      throw new Error("Skipping 'publish', missing config file: " +
-                      "taskcluster-base-test.conf.json");
-      return;
-    }
-
-    return mockAuthServer.api.publish({
-      baseUrl:              'http://localhost:23243/v1',
-      referencePrefix:      'base/test/api.json',
-      referenceBucket:      cfg.get('referenceTestBucket'),
-      aws:                  cfg.get('aws')
-    }).then(function() {
-      // Get the file... we don't bother checking the contents this is good
-      // enough
-      var s3 = new aws.S3(cfg.get('aws'));
-      return s3.getObject({
-        Bucket:     cfg.get('referenceTestBucket'),
-        Key:        'base/test/api.json'
-      }).promise();
-    }).then(function(res) {
-      var reference = JSON.parse(res.data.Body);
-      assert(reference.entries, "Missing entries");
-      assert(reference.entries.length > 0, "Has no entries");
-      assert(reference.title, "Missing title");
-    });
-  });
-
 
   // Test simple method
   test("publish minimal reference", function() {
@@ -108,7 +56,7 @@ suite("api/publish", function() {
         Key:        'base/test/simple-api.json'
       }).promise();
     }).then(function(res) {
-      var reference = JSON.parse(res.data.Body);
+      var reference = JSON.parse(res.Body);
       assert(reference.entries, "Missing entries");
       assert(reference.entries.length == 1, "Should have one entry");
       assert(reference.title, "Missing title");

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -49,7 +49,7 @@ suite("api/publish", function() {
         Key:        'base/test/api.json'
       }).promise();
     }).then(function(res) {
-      var reference = JSON.parse(res.Body);
+      var reference = JSON.parse(res.data.Body);
       assert(reference.entries, "Missing entries");
       assert(reference.entries.length > 0, "Has no entries");
       assert(reference.title, "Missing title");
@@ -108,7 +108,7 @@ suite("api/publish", function() {
         Key:        'base/test/simple-api.json'
       }).promise();
     }).then(function(res) {
-      var reference = JSON.parse(res.Body);
+      var reference = JSON.parse(res.data.Body);
       assert(reference.entries, "Missing entries");
       assert(reference.entries.length == 1, "Should have one entry");
       assert(reference.title, "Missing title");

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -3,7 +3,7 @@ suite("api/route", function() {
   var request         = require('superagent-promise');
   var assert          = require('assert');
   var Promise         = require('promise');
-  var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
+  var testing         = require('taskcluster-lib-testing');
   var validator       = require('taskcluster-lib-validate');
   var subject         = require('../');
   var express         = require('express');
@@ -79,54 +79,46 @@ suite("api/route", function() {
     res.status(200).send(req.params.param2);
   });
 
-  // Reference to mock authentication server
-  var _mockAuthServer = null;
   // Reference for test api server
   var _apiServer = null;
 
   // Create a mock authentication server
   setup(function(){
-    assert(_mockAuthServer === null,  "_mockAuthServer must be null");
+    testing.fakeauth.start();
     assert(_apiServer === null,       "_apiServer must be null");
-    return mockAuthServer({
-      port:         23243
-    }).then(function(server) {
-      _mockAuthServer = server;
-    }).then(function() {
-      // Create server for api
-      return validator({
-        folder: path.join(__dirname, 'schemas'),
-        baseUrl:        'http://localhost:4321/',
-      }).then(function(validator) {
+    // Create server for api
+    return validator({
+      folder: path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/',
+    }).then(function(validator) {
 
-        // Create router
-        var router = api.router({
-          validator:      validator,
-          authBaseUrl:    'http://localhost:23243'
+      // Create router
+      var router = api.router({
+        validator:      validator,
+        authBaseUrl:    'http://localhost:23243'
+      });
+
+
+      // Create application
+      var app = express();
+
+      // Use router
+      app.use(router);
+
+      return new Promise(function(accept, reject) {
+        var server = app.listen(23525);
+        server.once('listening', function() {
+          accept(server)
         });
-
-
-        // Create application
-        var app = express();
-
-        // Use router
-        app.use(router);
-
-        return new Promise(function(accept, reject) {
-          var server = app.listen(23525);
-          server.once('listening', function() {
-            accept(server)
-          });
-          server.once('error', reject);
-          _apiServer = server;
-        });
+        server.once('error', reject);
+        _apiServer = server;
       });
     });
   });
 
   // Close server
   teardown(function() {
-    assert(_mockAuthServer, "_mockAuthServer doesn't exist");
+    testing.fakeauth.stop();
     assert(_apiServer,      "_apiServer doesn't exist");
     return new Promise(function(accept) {
       _apiServer.once('close', function() {
@@ -134,14 +126,6 @@ suite("api/route", function() {
         accept();
       });
       _apiServer.close();
-    }).then(function() {
-      return new Promise(function(accept) {
-        _mockAuthServer.once('close', function() {
-          _mockAuthServer = null;
-          accept();
-        });
-        _mockAuthServer.close();
-      });
     });
   });
 

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -3,7 +3,7 @@ suite("api/schemaPrefix", function() {
   var request         = require('superagent-promise');
   var assert          = require('assert');
   var Promise         = require('promise');
-  var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
+  var testing         = require('taskcluster-lib-testing');
   var validator       = require('taskcluster-lib-validate');
   var subject         = require('../');
   var express         = require('express');
@@ -40,55 +40,47 @@ suite("api/schemaPrefix", function() {
     res.reply({value: 4});
   });
 
-  // Reference to mock authentication server
-  var _mockAuthServer = null;
   // Reference for test api server
   var _apiServer = null;
 
   // Create a mock authentication server
   setup(function(){
-    assert(_mockAuthServer === null,  "_mockAuthServer must be null");
+    testing.fakeauth.start();
     assert(_apiServer === null,       "_apiServer must be null");
-    return mockAuthServer({
-      port:         61243
-    }).then(function(server) {
-      _mockAuthServer = server;
-    }).then(function() {
-      // Create validator
-      var validatorCreated = validator({
-        folder:         path.join(__dirname, 'schemas'),
-        baseUrl:        'http://localhost:4321/'
+    // Create validator
+    var validatorCreated = validator({
+      folder:         path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/'
+    });
+
+    // Create server for api
+    return validatorCreated.then(function(validator) {
+      // Create router
+      var router = api.router({
+        validator:      validator,
+        authBaseUrl:    'http://localhost:61243'
       });
 
-      // Create server for api
-      return validatorCreated.then(function(validator) {
-        // Create router
-        var router = api.router({
-          validator:      validator,
-          authBaseUrl:    'http://localhost:61243'
+      // Create application
+      var app = express();
+
+      // Use router
+      app.use(router);
+
+      return new Promise(function(accept, reject) {
+        var server = app.listen(61515);
+        server.once('listening', function() {
+          accept(server)
         });
-
-        // Create application
-        var app = express();
-
-        // Use router
-        app.use(router);
-
-        return new Promise(function(accept, reject) {
-          var server = app.listen(61515);
-          server.once('listening', function() {
-            accept(server)
-          });
-          server.once('error', reject);
-          _apiServer = server;
-        });
+        server.once('error', reject);
+        _apiServer = server;
       });
     });
   });
 
   // Close server
   teardown(function() {
-    assert(_mockAuthServer, "_mockAuthServer doesn't exist");
+    testing.fakeauth.stop();
     assert(_apiServer,      "_apiServer doesn't exist");
     return new Promise(function(accept) {
       _apiServer.once('close', function() {
@@ -96,14 +88,6 @@ suite("api/schemaPrefix", function() {
         accept();
       });
       _apiServer.close();
-    }).then(function() {
-      return new Promise(function(accept) {
-        _mockAuthServer.once('close', function() {
-          _mockAuthServer = null;
-          accept();
-        });
-        _mockAuthServer.close();
-      });
     });
   });
 

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -1,7 +1,6 @@
 suite("api/route", function() {
   var assert          = require('assert');
   var Promise         = require('promise');
-  var mockAuthServer  = require('taskcluster-lib-testing/.test/mockauthserver');
   var subject         = require('../');
   var express         = require('express');
   var path            = require('path');


### PR DESCRIPTION
This makes the weird import go away. It didn't end up being as hard as I expected, which worries me that tests are just passing for no reason now. If you know of any areas where I missed something, please let me know.

I removed the test "reference from mockAuthServer" entirely because it seemed to just be re-testing something that is testing a bit more simply down below it in the same file. If the extra complexity is worth it, I can go and re-create a mockAuthServer type thing to test publishing on, but I don't believe it is worth it.

The diff here looks a log bigger than it actually is. Most of the "changed" lines are just removing whitespace at the beginning as they became one level less deep inside promises.

bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1298398