### PR TITLE
Bug 1330978: reduce redundancy in API error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ into `details`, with the result being JSON-encoded.  For example:
 ```js
 res.reportError(
   'TooManyFoos',
-  'You can only have 3 foos.  You provided:\n{{foos}}',
-  {foos: req.body.foos})
+  'You can only have 3 foos.  These foos already exist:\n{{foos}}',
+  {foos: foomanager.foos(request.fooId)});
 ```
 
 The resulting HTTP response will have a JSON body containing (whitespace adjusted)
@@ -282,12 +282,11 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
 {
   "code": "TooManyFoos",
   "message": "You can only have 3 foos.
-    You provided:
+    These foos already exist:
     [
       1,
       2,
-      3,
-      4
+      3
     ]
     ----
     method:     toomanyfoos
@@ -297,11 +296,14 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
   "requestInfo":{
     "method": "toomanyfoos",
     "params": {},
-    "payload": {"foos":[1,2,3,4]},
+    "payload": {"foos":[4, 5]},
     "time": "2017-01-22T21:20:16.650Z",
   },
 }
 ```
+
+The request payload is provided in `requestInfo`, so there is no need to
+reproduce its contents within the error message.
 
 *Note:* use of `res.status(4..).json(..)` to return error statuses is an
 anti-pattern.  While you may see older code that still follows this pattern, do

--- a/README.md
+++ b/README.md
@@ -303,7 +303,6 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
     "payload": {"foos":[1,2,3,4]},
     "time": "2017-01-22T21:20:16.650Z",
   },
-  "details": {"foos":[1,2,3,4]}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -290,13 +290,10 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
       4
     ]
     ----
+    method:     toomanyfoos
     errorCode:  TooManyFoos
     statusCode: 472
-    requestInfo:
-      method:   toomanyfoos
-      params:   {}
-      payload:  {\"foos\": [1,2,3,4]}
-      time:     2017-01-22T21:20:16.650Z",
+    time:       2017-01-22T21:20:16.650Z",
   "requestInfo":{
     "method": "toomanyfoos",
     "params": {},

--- a/README.md
+++ b/README.md
@@ -273,8 +273,38 @@ into `details`, with the result being JSON-encoded.  For example:
 ```js
 res.reportError(
   'TooManyFoos',
-  'You can only have 7 foos.  You provided:\n{{foos}}',
+  'You can only have 3 foos.  You provided:\n{{foos}}',
   {foos: req.body.foos})
+```
+
+The resulting HTTP response will have a JSON body containing (whitespace adjusted)
+```js
+{
+  "code": "TooManyFoos",
+  "message": "You can only have 3 foos.
+    You provided:
+    [
+      1,
+      2,
+      3,
+      4
+    ]
+    ----
+    errorCode:  TooManyFoos
+    statusCode: 472
+    requestInfo:
+      method:   toomanyfoos
+      params:   {}
+      payload:  {\"foos\": [1,2,3,4]}
+      time:     2017-01-22T21:20:16.650Z",
+  "requestInfo":{
+    "method": "toomanyfoos",
+    "params": {},
+    "payload": {"foos":[1,2,3,4]},
+    "time": "2017-01-22T21:20:16.650Z",
+  },
+  "details": {"foos":[1,2,3,4]}
+}
 ```
 
 *Note:* use of `res.status(4..).json(..)` to return error statuses is an

--- a/src/errors.js
+++ b/src/errors.js
@@ -62,13 +62,10 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
         return value;
       }) + [
         '\n----',
+        'method:     ' + method,
         'errorCode:  ' + code,
         'statusCode: ' + status,
-        'requestInfo:',
-        '  method:   ' + requestInfo.method,
-        '  params:   ' + JSON.stringify(requestInfo.params),
-        '  payload:  ' + JSON.stringify(payload, null, 2),
-        '  time:     ' + requestInfo.time,
+        'time:       ' + requestInfo.time,
       ].join('\n');
       res.status(status).json({code, message, requestInfo});
     };

--- a/src/errors.js
+++ b/src/errors.js
@@ -69,8 +69,6 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
         '  params:   ' + JSON.stringify(requestInfo.params),
         '  payload:  ' + JSON.stringify(payload, null, 2),
         '  time:     ' + requestInfo.time,
-        'details:',
-        JSON.stringify(details, null, 2),
       ].join('\n');
       res.status(status).json({code, message, requestInfo, details});
     };

--- a/src/errors.js
+++ b/src/errors.js
@@ -70,7 +70,7 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
         '  payload:  ' + JSON.stringify(payload, null, 2),
         '  time:     ' + requestInfo.time,
       ].join('\n');
-      res.status(status).json({code, message, requestInfo, details});
+      res.status(status).json({code, message, requestInfo});
     };
     res.reportInternalError = (err, tags = {}) => {
       let incidentId = uuid.v4();

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -52,11 +52,11 @@ suite("api/errors", function() {
     title:    "Test End-Point",
     description:  "Place we can call to test something",
   }, function(req, res) {
-    req.body.foos = [1, 2, 3, 4];
+    req.body.foos = [4, 5];
     res.reportError(
       'TooManyFoos',
-      'You can only have 3 foos.  You provided:\n{{foos}}',
-      {foos: req.body.foos});
+      'You can only have 3 foos.  These foos already exist:\n{{foos}}',
+      {foos: [1, 2, 3]});
   });
 
   test("TooManyFoos response", async function() {
@@ -71,12 +71,11 @@ suite("api/errors", function() {
     assert(_.isEqual(response, {
       code: "TooManyFoos",
       message: [
-        "You can only have 3 foos.  You provided:",
+        "You can only have 3 foos.  These foos already exist:",
         "[",
         "  1,",
         "  2,",
-        "  3,",
-        "  4",
+        "  3",
         "]",
         "----",
         "method:     toomanyfoos",
@@ -87,9 +86,7 @@ suite("api/errors", function() {
       requestInfo: {
         method: "toomanyfoos",
         params: {},
-        payload: {
-          foos: [1, 2, 3, 4]
-        },
+        payload: {foos: [4, 5]},
         time: "<nowish>"
       },
     }));

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -79,20 +79,10 @@ suite("api/errors", function() {
         "  4",
         "]",
         "----",
+        "method:     toomanyfoos",
         "errorCode:  TooManyFoos",
         "statusCode: 472",
-        "requestInfo:",
-        "  method:   toomanyfoos",
-        "  params:   {}",
-        "  payload:  {",
-        "  \"foos\": [",
-        "    1,",
-        "    2,",
-        "    3,",
-        "    4",
-        "  ]",
-        "}",
-        "  time:     <nowish>",
+        "time:       <nowish>",
       ].join('\n'),
       requestInfo: {
         method: "toomanyfoos",
@@ -155,10 +145,9 @@ suite("api/errors", function() {
       .end();
     assert(res.statusCode === 400);
     let response = JSON.parse(res.text);
+    assert(!/s3kr!t/.test(res.text)); // secret does not appear in response
     assert(response.code === 'InputValidationError');
-    console.log(response.message);
-    assert(/<HIDDEN>/.test(response.message)); // replaced payload appears in message
-    assert(!/s3kr!t/.test(response.message)); // secret does not appear in message
+    assert(response.requestInfo.payload.secret == '<HIDDEN>'); // replaced payload appears in response
     delete response.requestInfo['time'];
     assert(_.isEqual(response.requestInfo, {
       method: 'InputValidationError',

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -37,14 +37,12 @@ suite("api/errors", function() {
     let response = JSON.parse(res.text);
     assert(response.code === 'InputError');
     assert(/Testing Error\n----\n/.test(response.message));
-    assert(!/details:/.test(response.message)); // no details in message..
     delete response.requestInfo['time'];
     assert(_.isEqual(response.requestInfo, {
       method: 'InputError',
       params: {},
       payload: {},
     }));
-    assert(_.isEqual(response.details, {dee: 'tails'}));
   });
 
   api.declare({
@@ -104,9 +102,6 @@ suite("api/errors", function() {
         },
         time: "<nowish>"
       },
-      details: {
-        foos: [1, 2, 3, 4]
-      }
     }));
   });
 
@@ -169,9 +164,6 @@ suite("api/errors", function() {
       method: 'InputValidationError',
       params: {},
       payload: {'invalid': 'yep', 'secret': '<HIDDEN>'},
-    }));
-    assert(_.isEqual(response.details, {
-      schema: 'http://localhost:4321/test-schema.json',
     }));
   });
 });


### PR DESCRIPTION
The tests have some nice summaries of the error payloads at each stage of this.

My thinking is to get this in place, then do some work on the tools site to just show message by default, with an 'advanced' button to show the request info.  It occurs to me, maybe that request info should include the service name somehow, to help the user understand which call failed?