### PR TITLE
Allow an endpoint to be declared as noPublish

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -867,7 +867,7 @@ API.prototype.reference = function(options) {
     title:              this._options.title,
     description:        this._options.description,
     baseUrl:            options.baseUrl,
-    entries: _.concat(this._entries, [ping]).map(function(entry) {
+    entries: _.concat(this._entries, [ping]).filter(entry => !entry.noPublish).map(function(entry) {
       // Find parameters for entry
       var params  = [];
       // Note: express uses the NPM module path-to-regexp for parsing routes

--- a/src/api.js
+++ b/src/api.js
@@ -653,6 +653,9 @@ var STABILITY_LEVELS = _.values(stability);
  *   skipInputValidation:    true,               // defaults to false
  *   skipOutputValidation:   true,               // defaults to false
  *   title:     "My API Method",
+ *   noPublish: true                             // defaults to false, causes
+ *                                               // endpoint to be left out of api
+ *                                               // references
  *   description: [
  *     "Description of method in markdown, enjoy"
  *   ].join('\n'),


### PR DESCRIPTION
This means that the API will be ignored for publishing reference files, and thus invisible in documentation and client libraries, but will still be set up in the Express routing framework.  This means that we can support old APIs while not advertising their existance