### PR TITLE
Add a noAuth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ To declare an API method, call `api.declare(options, handler)` with the followin
  * `scopes` - scopes required for this API endpoint, in disjunctive normal form (see below)
  * `deferAuth` - if true, authentication will not be checked automatically before the handler
    is invoked.  In this case, the handler must call `req.satisfies()`; see below.
+ * `noAuth` - if true, this endpoint will not be authenticated and clients should not send
+   headers or bewit
  * `stability` - API stability level, defaulting to experimental (see below)
  * `input` - the schema against which the input payload will be validated
  * `skipInputValidation` - if true, don't do input validation (but include the schema in documentation)

--- a/src/api.js
+++ b/src/api.js
@@ -382,8 +382,8 @@ var remoteAuthentication = function(options, entry) {
     }
 
     // If no authentication is provided, we just return valid with zero scopes
-    if ((!req.query || !req.query.bewit) &&
-        (!req.headers || !req.headers.authorization)) {
+    if (entry.noAuth || ((!req.query || !req.query.bewit) &&
+        (!req.headers || !req.headers.authorization))) {
       return Promise.resolve({
         status: 'no-auth',
         scheme: 'none',
@@ -679,6 +679,10 @@ API.prototype.declare = function(options, handler) {
   if (!options.stability) {
     options.stability = stability.experimental;
   }
+  if (!options.noAuth) {
+    options.noAuth = false;
+  }
+  assert(!options.scopes || !options.noAuth, 'Cannot specify noAuth if the function has scopes');
   assert(STABILITY_LEVELS.indexOf(options.stability) !== -1,
          "options.stability must be a valid stability-level, " +
          "see base.API.stability for valid options");

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -92,6 +92,20 @@ suite("api/auth", function() {
     }
   });
 
+  // Declare a method we can test no auth
+  api.declare({
+    method:       'get',
+    route:        '/test-no-auth',
+    name:         'testNoAuth',
+    noAuth:       true,
+    title:        "Test End-Point",
+    description:  "Place we can call to test something",
+  }, function(req, res) {
+    if(req.satisfies([req.body.scopes])) {
+      return res.status(200).json("OK");
+    }
+  });
+
   // Create a mock authentication server
   setup(async () => {
     testing.fakeauth.start({
@@ -292,6 +306,22 @@ suite("api/auth", function() {
         key:          'groupie',
         algorithm:    'sha256'
       })
+      .end()
+      .then(function(res) {
+        if(!res.ok) {
+          console.log(JSON.stringify(res.body));
+          assert(false, "Request failed");
+        }
+      });
+  });
+
+  // Test with no authentication
+  test("With no authentication", function() {
+    var url = 'http://localhost:23526/test-no-auth';
+    return request
+      .get(url)
+      .send()
+      .hawk()
       .end()
       .then(function(res) {
         if(!res.ok) {


### PR DESCRIPTION
Does this generally make sense for endpoints like authenticateHawk?

https://bugzilla.mozilla.org/show_bug.cgi?id=1352581