### PR TITLE
Bug 1338047 - Migrate all taskcluster-lib-* libraries to use import/export syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .vagrant/
 lib/
+.test/

--- a/src/api.js
+++ b/src/api.js
@@ -19,8 +19,8 @@ import cryptiles from 'cryptiles';
 import taskcluster from 'taskcluster-client';
 import Ajv from 'ajv';
 import typeis from 'type-is';
-import 'superagent-hawk';
-import 'superagent';
+
+require('superagent-hawk')(require('superagent'));
   
 
 // Default baseUrl for authentication server

--- a/src/api.js
+++ b/src/api.js
@@ -1,25 +1,27 @@
 "use strict";
 
-var express       = require('express');
-var Debug         = require('debug');
-var Promise       = require('promise');
-var uuid          = require('uuid');
-var hawk          = require('hawk');
-var aws           = require('aws-sdk');
-var assert        = require('assert');
-var _             = require('lodash');
-var bodyParser    = require('body-parser');
-var path          = require('path');
-var fs            = require('fs');
-require('superagent-hawk')(require('superagent'));
-var request       = require('superagent-promise');
-var scopes        = require('taskcluster-lib-scopes');
-var crypto        = require('crypto');
-var cryptiles     = require('cryptiles');
-var taskcluster   = require('taskcluster-client');
-var Ajv           = require('ajv');
-var errors        = require('./errors');
-var typeis        = require('type-is');
+import * as express from 'express';
+import * as _ from 'lodash';
+import * as scopes from 'taskcluster-lib-scopes';
+import * as errors from  './errors';
+import Debug from 'debug';
+import Promise from 'promise';
+import uuid from 'uuid';
+import hawk from 'hawk';
+import aws from 'aws-sdk';
+import assert from 'assert';
+import bodyParser from 'body-parser';
+import path from 'path';
+import fs from 'fs';
+import request from 'superagent-promise';
+import crypto from 'crypto';
+import cryptiles from 'cryptiles';
+import taskcluster from 'taskcluster-client';
+import Ajv from 'ajv';
+import typeis from 'type-is';
+import 'superagent-hawk';
+import 'superagent';
+  
 
 // Default baseUrl for authentication server
 var AUTH_BASE_URL = 'https://auth.taskcluster.net/v1';
@@ -150,7 +152,7 @@ var schema = function(validate, options) {
     // code 200... errors should be sent with res.json(code, json)
     res.reply = function(json) {
       // If we're supposed to validate outgoing messages and output schema is
-      // defined, then we have to validate against it...
+      // defined, then we have to validate _against it...
       if(options.output !== undefined && !options.skipOutputValidation &&
          options.output !== 'blob') {
         var error = validate(json, options.output);
@@ -564,7 +566,7 @@ var handle = function(handler, context, name) {
  * is called it'll use the currently defined entries to mount or publish the
  * API.
  */
-var API = function(options) {
+export default function API(options) {
   ['title', 'description'].forEach(function(key) {
     assert(options[key], "Option '" + key + "' must be provided");
   });
@@ -581,7 +583,7 @@ var API = function(options) {
     assert(typeof(value) === 'number', 'Expected HTTP status code to be int');
   });
   this._entries = [];
-};
+}
 
 /** Stability levels offered by API method */
 var stability = {
@@ -1001,11 +1003,12 @@ API.prototype.setup = function(options) {
 };
 
 // Export API
-module.exports = API;
-
+// module.exports = API;
+//export default API;
 // Export middleware utilities
 API.schema        = schema;
 API.handle        = handle;
 API.stability     = stability;
 API.nonceManager  = nonceManager;
 API.remoteAuthentication = remoteAuthentication;
+

--- a/src/api.js
+++ b/src/api.js
@@ -152,7 +152,7 @@ var schema = function(validate, options) {
     // code 200... errors should be sent with res.json(code, json)
     res.reply = function(json) {
       // If we're supposed to validate outgoing messages and output schema is
-      // defined, then we have to validate _against it...
+      // defined, then we have to validate against it...
       if(options.output !== undefined && !options.skipOutputValidation &&
          options.output !== 'blob') {
         var error = validate(json, options.output);
@@ -566,6 +566,7 @@ var handle = function(handler, context, name) {
  * is called it'll use the currently defined entries to mount or publish the
  * API.
  */
+ //Export API
 export default function API(options) {
   ['title', 'description'].forEach(function(key) {
     assert(options[key], "Option '" + key + "' must be provided");
@@ -1002,9 +1003,6 @@ API.prototype.setup = function(options) {
   });
 };
 
-// Export API
-// module.exports = API;
-//export default API;
 // Export middleware utilities
 API.schema        = schema;
 API.handle        = handle;

--- a/src/errors.js
+++ b/src/errors.js
@@ -20,7 +20,6 @@ const ERROR_CODES = {
 };
 
 // Export ERROR_CODES
-// exports.ERROR_CODES = ERROR_CODES;
 export {ERROR_CODES}
 /**
  * Middleware that adds `res.reportError(code, message, details)` and
@@ -93,5 +92,4 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
 };
 
 // Export BuildReportErrorMethod
-// exports.BuildReportErrorMethod = BuildReportErrorMethod;
 export {BuildReportErrorMethod}

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,9 @@
-let uuid = require('uuid');
-let debug = require('debug')('base:api');
-let _ = require('lodash');
+import uuid from 'uuid';
+import debug from 'debug';
+import * as _ from 'lodash';
+//let uuid = require('uuid');
+//let debug = require('debug')('base:api');
+//let _ = require('lodash');
 
 const ERROR_CODES = {
   MalformedPayload:         400,  // Only for JSON.parse() errors
@@ -17,8 +20,8 @@ const ERROR_CODES = {
 };
 
 // Export ERROR_CODES
-exports.ERROR_CODES = ERROR_CODES;
-
+// exports.ERROR_CODES = ERROR_CODES;
+export {ERROR_CODES}
 /**
  * Middleware that adds `res.reportError(code, message, details)` and
  * `res.reportInternalError(error)`.
@@ -90,4 +93,5 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
 };
 
 // Export BuildReportErrorMethod
-exports.BuildReportErrorMethod = BuildReportErrorMethod;
+// exports.BuildReportErrorMethod = BuildReportErrorMethod;
+export {BuildReportErrorMethod}

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -1,17 +1,32 @@
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import validator from 'taskcluster-lib-validate';
+import makeApp from 'taskcluster-lib-app';
+import * as express from 'express';
+import hawk from 'hawk';
+import  slugid from 'slugid';
+import crypto from 'crypto';
+import testing from 'taskcluster-lib-testing';
+import path from 'path';
+import 'superagent-hawk';
+import 'superagent';
 suite("api/auth", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var validator       = require('taskcluster-lib-validate');
-  var makeApp         = require('taskcluster-lib-app');
-  var subject         = require('../');
-  var express         = require('express');
-  var hawk            = require('hawk');
-  var slugid          = require('slugid');
-  var crypto          = require('crypto');
-  var testing         = require('taskcluster-lib-testing');
-  var path            = require('path');
+  // require('superagent-hawk')(require('superagent'));
+  // var request         = require('superagent-promise');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var validator       = require('taskcluster-lib-validate');
+  // var makeApp         = require('taskcluster-lib-app');
+  // var subject         = require('../');
+
+  // var express         = require('express');
+  // var hawk            = require('hawk');
+  // var slugid          = require('slugid');
+  // var crypto          = require('crypto');
+  // var testing         = require('taskcluster-lib-testing');
+  // var path            = require('path');
 
   // Reference for test api server
   var _apiServer = null;

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -10,10 +10,10 @@ import  slugid from 'slugid';
 import crypto from 'crypto';
 import testing from 'taskcluster-lib-testing';
 import path from 'path';
-import 'superagent-hawk';
-import 'superagent';
-suite("api/auth", function() {
 
+suite("api/auth", function() {
+  
+  require('superagent-hawk')(require('superagent'));
   // Reference for test api server
   var _apiServer = null;
 

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -13,20 +13,6 @@ import path from 'path';
 import 'superagent-hawk';
 import 'superagent';
 suite("api/auth", function() {
-  // require('superagent-hawk')(require('superagent'));
-  // var request         = require('superagent-promise');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var validator       = require('taskcluster-lib-validate');
-  // var makeApp         = require('taskcluster-lib-app');
-  // var subject         = require('../');
-
-  // var express         = require('express');
-  // var hawk            = require('hawk');
-  // var slugid          = require('slugid');
-  // var crypto          = require('crypto');
-  // var testing         = require('taskcluster-lib-testing');
-  // var path            = require('path');
 
   // Reference for test api server
   var _apiServer = null;

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -6,6 +6,7 @@ import Promise from 'promise';
 import request from 'superagent-promise';
 import  slugid from 'slugid';
 import path from 'path';
+
 suite("API (context)", function() {
 
   test("Provides context", async () => {

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -7,14 +7,6 @@ import request from 'superagent-promise';
 import  slugid from 'slugid';
 import path from 'path';
 suite("API (context)", function() {
-  // var validator       = require('taskcluster-lib-validate');
-  // var makeApp         = require('taskcluster-lib-app');
-  // var subject         = require('../');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var request         = require('superagent-promise');
-  // var slugid          = require('slugid');
-  // var path            = require('path');
 
   test("Provides context", async () => {
     // Create test api

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -1,12 +1,20 @@
+import subject from '../';
+import validator from 'taskcluster-lib-validate';
+import makeApp from 'taskcluster-lib-app';
+import assert from 'assert';
+import Promise from 'promise';
+import request from 'superagent-promise';
+import  slugid from 'slugid';
+import path from 'path';
 suite("API (context)", function() {
-  var validator       = require('taskcluster-lib-validate');
-  var makeApp         = require('taskcluster-lib-app');
-  var subject         = require('../');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var request         = require('superagent-promise');
-  var slugid          = require('slugid');
-  var path            = require('path');
+  // var validator       = require('taskcluster-lib-validate');
+  // var makeApp         = require('taskcluster-lib-app');
+  // var subject         = require('../');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var request         = require('superagent-promise');
+  // var slugid          = require('slugid');
+  // var path            = require('path');
 
   test("Provides context", async () => {
     // Create test api

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -7,13 +7,6 @@ import * as helper from  './helper';
 import 'superagent-hawk';
 import 'superagent';
 suite("api/errors", function() {
-  // require('superagent-hawk')(require('superagent'));
-  // var request         = require('superagent-promise');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var subject         = require('../');
-  // var helper          = require('./helper');
-  // var _               = require('lodash');
 
   // Create test api
   var api = new subject({

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -4,10 +4,10 @@ import request from 'superagent-promise';
 import assert from 'assert';
 import Promise from 'promise';
 import * as helper from  './helper';
-import 'superagent-hawk';
-import 'superagent';
+
 suite("api/errors", function() {
 
+  require('superagent-hawk')(require('superagent'));
   // Create test api
   var api = new subject({
     title:        "Test Api",

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -1,11 +1,19 @@
+import * as _ from 'lodash';
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import * as helper from  './helper';
+import 'superagent-hawk';
+import 'superagent';
 suite("api/errors", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var subject         = require('../');
-  var helper          = require('./helper');
-  var _               = require('lodash');
+  // require('superagent-hawk')(require('superagent'));
+  // var request         = require('superagent-promise');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var subject         = require('../');
+  // var helper          = require('./helper');
+  // var _               = require('lodash');
 
   // Create test api
   var api = new subject({

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,11 +3,6 @@ import validate from 'taskcluster-lib-validate';
 import assert from 'assert';
 import path from 'path';
 import express from 'express';
-// var testing         = require('taskcluster-lib-testing');
-// var validate        = require('taskcluster-lib-validate');
-// var assert          = require('assert');
-// var path            = require('path');
-// var express         = require('express');
 
 var runningServer = null;
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,13 @@
-var testing         = require('taskcluster-lib-testing');
-var validate        = require('taskcluster-lib-validate');
-var assert          = require('assert');
-var path            = require('path');
-var express         = require('express');
+import testing from 'taskcluster-lib-testing';
+import validate from 'taskcluster-lib-validate';
+import assert from 'assert';
+import path from 'path';
+import express from 'express';
+// var testing         = require('taskcluster-lib-testing');
+// var validate        = require('taskcluster-lib-validate');
+// var assert          = require('assert');
+// var path            = require('path');
+// var express         = require('express');
 
 var runningServer = null;
 

--- a/test/noncemanager_test.js
+++ b/test/noncemanager_test.js
@@ -3,10 +3,6 @@ import assert from 'assert';
 import Promise from 'promise';
 import debug from 'debug';
 suite("nonceManager test", function() {
-  //var subject         = require('../');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var debug           = require('debug')('base:test:nonceManager');
 
   // Create a new nonceManager for each test
   var nonceManager = null;

--- a/test/noncemanager_test.js
+++ b/test/noncemanager_test.js
@@ -1,8 +1,12 @@
+import subject from '../';
+import assert from 'assert';
+import Promise from 'promise';
+import debug from 'debug';
 suite("nonceManager test", function() {
-  var subject         = require('../');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var debug           = require('debug')('base:test:nonceManager');
+  //var subject         = require('../');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var debug           = require('debug')('base:test:nonceManager');
 
   // Create a new nonceManager for each test
   var nonceManager = null;

--- a/test/noncemanager_test.js
+++ b/test/noncemanager_test.js
@@ -1,9 +1,10 @@
 import subject from '../';
 import assert from 'assert';
 import Promise from 'promise';
-import debug from 'debug';
+import Debug from 'debug';
 suite("nonceManager test", function() {
 
+  var debug = Debug('base:test:nonceManager');
   // Create a new nonceManager for each test
   var nonceManager = null;
   setup(function() {

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -1,9 +1,14 @@
+import subject from '../';
+import config from 'taskcluster-lib-config';
+import aws from 'aws-sdk';
+import assert from 'assert';
+import Promise from 'promise';
 suite("api/publish", function() {
-  var subject         = require('../');
-  var config          = require('taskcluster-lib-config');
-  var aws             = require('aws-sdk');
-  var assert          = require('assert');
-  var Promise         = require('promise');
+  // var subject         = require('../');
+  // var config          = require('taskcluster-lib-config');
+  // var aws             = require('aws-sdk');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
 
   var cfg = config({
     envs: [

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -4,11 +4,6 @@ import aws from 'aws-sdk';
 import assert from 'assert';
 import Promise from 'promise';
 suite("api/publish", function() {
-  // var subject         = require('../');
-  // var config          = require('taskcluster-lib-config');
-  // var aws             = require('aws-sdk');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
 
   var cfg = config({
     envs: [

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -8,13 +8,6 @@ import 'superagent-hawk';
 import 'superagent';
 
 suite("api/responsetimer", function() {
-  // require('superagent-hawk')(require('superagent'));
-  // var request         = require('superagent-promise');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // //var subject         = require('../');
-  // var monitoring      = require('taskcluster-lib-monitor');
-  // var helper          = require('./helper');
 
   // Create test api
   var api = new subject({

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -1,11 +1,20 @@
+import * as helper from  './helper';
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import monitoring from 'taskcluster-lib-monitor'
+import 'superagent-hawk';
+import 'superagent';
+
 suite("api/responsetimer", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var subject         = require('../');
-  var monitoring      = require('taskcluster-lib-monitor');
-  var helper          = require('./helper');
+  // require('superagent-hawk')(require('superagent'));
+  // var request         = require('superagent-promise');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // //var subject         = require('../');
+  // var monitoring      = require('taskcluster-lib-monitor');
+  // var helper          = require('./helper');
 
   // Create test api
   var api = new subject({

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -4,11 +4,10 @@ import request from 'superagent-promise';
 import assert from 'assert';
 import Promise from 'promise';
 import monitoring from 'taskcluster-lib-monitor'
-import 'superagent-hawk';
-import 'superagent';
 
 suite("api/responsetimer", function() {
 
+  require('superagent-hawk')(require('superagent'));
   // Create test api
   var api = new subject({
     title:        "Test Api",

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -7,13 +7,6 @@ import slugid from 'slugid';
 import 'superagent-hawk';
 import 'superagent';
 suite("api/route", function() {
-  // require('superagent-hawk')(require('superagent'));
-  // var request         = require('superagent-promise');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var subject         = require('../');
-  // var slugid          = require('slugid');
-  // var helper          = require('./helper');
 
   // Create test api
   var api = new subject({

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -1,11 +1,19 @@
+import * as helper from  './helper';
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import slugid from 'slugid';
+import 'superagent-hawk';
+import 'superagent';
 suite("api/route", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var subject         = require('../');
-  var slugid          = require('slugid');
-  var helper          = require('./helper');
+  // require('superagent-hawk')(require('superagent'));
+  // var request         = require('superagent-promise');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var subject         = require('../');
+  // var slugid          = require('slugid');
+  // var helper          = require('./helper');
 
   // Create test api
   var api = new subject({

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -4,10 +4,10 @@ import request from 'superagent-promise';
 import assert from 'assert';
 import Promise from 'promise';
 import slugid from 'slugid';
-import 'superagent-hawk';
-import 'superagent';
+
 suite("api/route", function() {
 
+  require('superagent-hawk')(require('superagent'));
   // Create test api
   var api = new subject({
     title:        "Test Api",

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -6,15 +6,7 @@ import Promise from 'promise';
 import testing from 'taskcluster-lib-testing';
 import validator from 'taskcluster-lib-validate';
 suite("api/schemaPrefix", function() {
-  // require('superagent-hawk')(require('superagent'));
-  // var request         = require('superagent-promise');
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var testing         = require('taskcluster-lib-testing');
-  // var validator       = require('taskcluster-lib-validate');
-  // var subject         = require('../');
-  // var helper          = require('./helper');
-
+  
   // Create test api
   var api = new subject({
     title:        "Test Api",

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -1,12 +1,19 @@
+import * as helper from  './helper';
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import testing from 'taskcluster-lib-testing';
+import validator from 'taskcluster-lib-validate';
 suite("api/schemaPrefix", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var testing         = require('taskcluster-lib-testing');
-  var validator       = require('taskcluster-lib-validate');
-  var subject         = require('../');
-  var helper          = require('./helper');
+  // require('superagent-hawk')(require('superagent'));
+  // var request         = require('superagent-promise');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var testing         = require('taskcluster-lib-testing');
+  // var validator       = require('taskcluster-lib-validate');
+  // var subject         = require('../');
+  // var helper          = require('./helper');
 
   // Create test api
   var api = new subject({

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -1,9 +1,14 @@
+import subject from '../';
+import assert from 'assert';
+import Promise from 'promise';
+import express from 'express';
+import path from 'path';
 suite("api/route", function() {
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var subject         = require('../');
-  var express         = require('express');
-  var path            = require('path');
+  // var assert          = require('assert');
+  // var Promise         = require('promise');
+  // var subject         = require('../');
+  // var express         = require('express');
+  // var path            = require('path');
 
 
   // Create test api

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -4,12 +4,6 @@ import Promise from 'promise';
 import express from 'express';
 import path from 'path';
 suite("api/route", function() {
-  // var assert          = require('assert');
-  // var Promise         = require('promise');
-  // var subject         = require('../');
-  // var express         = require('express');
-  // var path            = require('path');
-
 
   // Create test api
   var api = new subject({

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -1,11 +1,19 @@
+import * as helper from  './helper';
+import subject from '../';
+import request from 'superagent-promise';
+import assert from 'assert';
+import Promise from 'promise';
+import testing from 'taskcluster-lib-testing';
+//import 'superagent-hawk';
+//import 'superagent';
 suite("api/validate", function() {
-  require('superagent-hawk')(require('superagent'));
-  var request         = require('superagent-promise');
-  var assert          = require('assert');
-  var Promise         = require('promise');
-  var subject         = require('../');
-  var helper          = require('./helper');
-  var testing         = require('taskcluster-lib-testing');
+   require('superagent-hawk')(require('superagent'));
+   //var request         = require('superagent-promise');
+   //var assert          = require('assert');
+   //var Promise         = require('promise');
+   //var subject         = require('../');
+   //var helper          = require('./helper');
+   //var testing         = require('taskcluster-lib-testing');
 
 
   // Create test api

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -4,18 +4,10 @@ import request from 'superagent-promise';
 import assert from 'assert';
 import Promise from 'promise';
 import testing from 'taskcluster-lib-testing';
-//import 'superagent-hawk';
-//import 'superagent';
+
 suite("api/validate", function() {
-   require('superagent-hawk')(require('superagent'));
-   //var request         = require('superagent-promise');
-   //var assert          = require('assert');
-   //var Promise         = require('promise');
-   //var subject         = require('../');
-   //var helper          = require('./helper');
-   //var testing         = require('taskcluster-lib-testing');
 
-
+  require('superagent-hawk')(require('superagent'));
   // Create test api
   var api = new subject({
     title:        "Test Api",


### PR DESCRIPTION
Converted all the files to use import/export syntax , except [test/validate_test.js](https://github.com/taskcluster/taskcluster-lib-api/blob/master/test/validate_test.js).
Following error on migrating the rest of the file.
```
1) api/auth request with static scope:
     TypeError: _superagentPromise2.default.get(...).hawk is not a function
2) api/auth request with static scope - fail no scope:
     TypeError: _superagentPromise2.default.get(...).hawk is not a function
3) api/auth static-scope with authorizedScopes:
     TypeError: _superagentPromise2.default.get(...).hawk is not a function
4) api/auth static-scope with authorizedScopes (star):
     TypeError: _superagentPromise2.default.get(...).hawk is not a function
```
...continues until (8)

