### PR TITLE
Use scope expressions for api authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,23 +137,27 @@ and `workerType`, *or* the caller's scopes satisfy all of
 `queue:define-task:..`, `queue:task-group-id:..`, and `queue:schedule-task:..`.
 
 ```js
-  scopes: {AnyOf: [
-    {AllOf: [
-      'queue:create-task:<provisionerId>/<workerType>',
+  scopes:
+    {AnyOf: [
+      {AllOf: [
+        'queue:create-task:<provisionerId>/<workerType>',
+      ]},
+      {AllOf: [
+        'queue:define-task:<provisionerId>/<workerType>',
+        'queue:task-group-id:<schedulerId>/<taskGroupId>',
+        'queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>',
+      ]},
     ]},
-    {AllOf: [
-      'queue:define-task:<provisionerId>/<workerType>',
-      'queue:task-group-id:<schedulerId>/<taskGroupId>',
-      'queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>',
-    ]},
-  ]},
 ```
 
 If scope validation fails, the user is presented with an extensive error
 message indicating the available and required scopes.
 
 Arrays of required scopes can also be templated in the scopes section. When
-this form is used, the parameter must be an array.
+this form is used, the parameter in the `in` section must be an array. The
+value of `each` *must* be a simple template string and cannot be a scope
+expression or another template object. This will not allow recursive
+definitions.
 
 ```js
   scopes: {AllOf: [

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ and `workerType`, *or* the caller's scopes satisfy all of
 If scope validation fails, the user is presented with an extensive error
 message indicating the available and required scopes.
 
-Given an array of parameters, an array of scopes can be templated using `for`. When
+Given an array of parameters, an array of scopes can be templated. When
 this form is used, the parameter in the `in` section must be an array. The
 value of `each` *must* be a simple template string and cannot be a scope
 expression or another template object. This will not allow recursive
@@ -274,9 +274,9 @@ includes some additional security token, its duration should be limited to this
 expiration time to prevent callers from extending their access beyond the
 allowed time.
 
-The `async req.authorize(params, options)` method returns `true` if the client satisfies
-the endpoint's scope expression. If the client does not satisfy the expression, it
-throws an error with the code 'AuthorizationError'. You can catch this if you wish
+The `async req.authorize(params, options)` throws an error with the code
+'AuthorizationError' if the client does not satisfy the scope
+expression in `options.scopes`. You can catch this if you wish
 or let it bubble up and taskcluster-lib-api will return a detailed error message
 to the client.
 
@@ -288,8 +288,7 @@ The AuthorizationError has 3 extra fields to help inspect the results.
 
 The first argument to `req.authorize` must be an object where the keys are parameters
 to the scope expression defined in the method definition. If any parameters are missing
-when you call this, the check will error unless you pass `options.allowLater`. This is
-only for special cases and should be rarely used. The rules for how the scope expression
+when you call this, the check will throw an error. The rules for how the scope expression
 defined in the method is transformed given a set of parameters is described above.
 
 To return a successful result with a JSON body, return `res.reply(result)`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ and `workerType`, *or* the caller's scopes satisfy all of
 If scope validation fails, the user is presented with an extensive error
 message indicating the available and required scopes.
 
-Arrays of required scopes can also be templated in the scopes section. When
+Given an array of parameters, an array of scopes can be templated using `for`. When
 this form is used, the parameter in the `in` section must be an array. The
 value of `each` *must* be a simple template string and cannot be a scope
 expression or another template object. This will not allow recursive
@@ -182,11 +182,11 @@ Given the following example:
   scopes: {if: 'private', then: {AllOf: ['foo:bar']}}
 ```
 
-We can call `authorize({private: false})` and the method call will be permitted
+We can call `async req.authorize({private: false})` and the method call will be permitted
 even if the client does not have the scope `foo:bar`.
 
 In addition, parameters can be nested objects and accessed with dotted notation.
-Given parameters `task` that is `{extra: {treeherder: {symbol: 'F'}}}`, we can do
+Given the parameter `task` that is `{extra: {treeherder: {symbol: 'F'}}}`, we can do
 the following:
 
 ```js
@@ -200,8 +200,8 @@ which evaluates to
 ```
 
 When you specify scopes required to access an endpoint, by default all of the params
-specified in the `params` section will be substituted in and the expression satisfaction
-will be checked against the client's scopes. If any of the parameters specified in
+specified in the `params` section of the request will be substituted in and the expression
+satisfaction will be checked against the client's scopes. If any of the parameters specified in
 your scopes are _not_ in the `params`, this satisfaction check will be deferred and the
 endpoint implementation _must_ check for authorization manually as described below. If
 this check does not occur, taskcluster-lib-api will throw an error for the result of the
@@ -274,7 +274,7 @@ includes some additional security token, its duration should be limited to this
 expiration time to prevent callers from extending their access beyond the
 allowed time.
 
-The `req.authorize(params, options)` method returns `true` if the client satisfies
+The `async req.authorize(params, options)` method returns `true` if the client satisfies
 the endpoint's scope expression. If the client does not satisfy the expression, it
 throws an error with the code 'AuthorizationError'. You can catch this if you wish
 or let it bubble up and taskcluster-lib-api will return a detailed error message

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This will not do any truthiness conversions, you must do that yourself if desire
 Given the following example:
 
 ```js
-  scopes: {AllOf: [{if: 'private', then: 'foo:bar'}]}
+  scopes: {if: 'private', then: {AllOf: ['foo:bar']}}
 ```
 
 We can call `authorize({private: false})` and the method call will be permitted

--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ this will evaluate to:
 
 You may also use if/then constructs in scope expressions. In this case, the `if`
 field should be a parameter and the `then` must be a scope expression that will
-be subsituted in for the if/then block if the `if` parameter exists and is truthy.
-Given the follwoing example:
+be subsituted in for the if/then block if the `if` parameter is a boolean and is true.
+This will not do any truthiness conversions, you must do that yourself if desired.
+Given the following example:
 
 ```js
   scopes: {AnyOf: ['foo:bar', {if: 'public', then: {AnyOf: []}}]}

--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ this will evaluate to:
   scopes: {AllOf: ['queue:route:foo', 'queue:route:bar']}
 ```
 
+You may also use if/then constructs in scope expressions. In this case, the `if`
+field should be a parameter and the `then` must be a scope expression that will
+be subsituted in for the if/then block if the `if` parameter exists and is truthy.
+Given the follwoing example:
+
+```js
+  scopes: {AnyOf: ['foo:bar', {if: 'public', then: {AnyOf: []}}]}
+```
+
+We can call `authorize({public: true})` and the method call will be permitted
+even if the client does not have the scope `foo:bar`.
+
 In addition, parameters can be nested objects and accessed with dotted notation.
 Given parameters `task` that is `{extra: {treeherder: {symbol: 'F'}}}`, we can do
 the following:

--- a/README.md
+++ b/README.md
@@ -276,7 +276,15 @@ allowed time.
 
 The `req.authorize(params, options)` method returns `true` if the client satisfies
 the endpoint's scope expression. If the client does not satisfy the expression, it
-returns `false` and sends an error message unless `options.noReply` is true.
+throws an error with the code 'AuthorizationError'. You can catch this if you wish
+or let it bubble up and taskcluster-lib-api will return a detailed error message
+to the client.
+
+The AuthorizationError has 3 extra fields to help inspect the results.
+
+**err.scopes:** The scopeset containing the scopes the client has
+**err.expression:** The scope expression that was not satisfied
+**err.missing:** The reduced subset of the expression containing only scopes that were missing
 
 The first argument to `req.authorize` must be an object where the keys are parameters
 to the scope expression defined in the method definition. If any parameters are missing

--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ This will not do any truthiness conversions, you must do that yourself if desire
 Given the following example:
 
 ```js
-  scopes: {AnyOf: ['foo:bar', {if: 'public', then: {AnyOf: []}}]}
+  scopes: {AllOf: [{if: 'private', then: 'foo:bar'}]}
 ```
 
-We can call `authorize({public: true})` and the method call will be permitted
+We can call `authorize({private: false})` and the method call will be permitted
 even if the client does not have the scope `foo:bar`.
 
 In addition, parameters can be nested objects and accessed with dotted notation.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ To declare an API method, call `api.declare(options, handler)` with the followin
  * `route` (required) - the URL pattern, with parameters, e.g., `'/object/:id/action/:param'`
  * `params` - patterns for URL parameters (see below)
  * `query` - patterns for query parameters (see below)
- * `scopes` - scopes required for this API endpoint, in disjunctive normal form (see below)
- * `deferAuth` - if true, authentication will not be checked automatically before the handler
-   is invoked.  In this case, the handler must call `req.satisfies()`; see below.
+ * `scopes` - scopes required for this API endpoint, in 'scope expression' form (see below)
  * `stability` - API stability level, defaulting to experimental (see below)
  * `input` - the schema against which the input payload will be validated
  * `skipInputValidation` - if true, don't do input validation (but include the schema in documentation)
@@ -130,28 +128,67 @@ Examples:
 
 ### Scopes
 
-Scopes should be specified in disjunctive normal form.  In other words, an
-array of arrays, where all of the scopes in at least one of the inner arrays
-must be satisfied.  Parameters are substituted into scopes with `<paramName>`
+Scopes should be specified in
+[scope expression form](https://github.com/taskcluster/taskcluster-lib-scopes#new-style).
+Parameters are substituted into scopes with `<paramName>`
 syntax.  For example, the following defintion allows the method when *either*
 the caller's scopes satisfy `queue:create-task..` for the given `provisionerId`
 and `workerType`, *or* the caller's scopes satisfy all of
 `queue:define-task:..`, `queue:task-group-id:..`, and `queue:schedule-task:..`.
 
 ```js
-  scopes: [
-    [
+  scopes: {AnyOf: [
+    {AllOf: [
       'queue:create-task:<provisionerId>/<workerType>',
-    ], [
+    ]},
+    {AllOf: [
       'queue:define-task:<provisionerId>/<workerType>',
       'queue:task-group-id:<schedulerId>/<taskGroupId>',
       'queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>',
-    ],
-  ],
+    ]},
+  ]},
 ```
 
 If scope validation fails, the user is presented with an extensive error
 message indicating the available and required scopes.
+
+Arrays of required scopes can also be templated in the scopes section. When
+this form is used, the parameter must be an array.
+
+```js
+  scopes: {AllOf: [
+    {for: 'route', in: 'routes', each: 'queue:route:<route>'}
+  ]}
+```
+
+Given a parameter `routes` that is an array of strings as in `['foo', 'bar']`,
+this will evaluate to:
+
+```js
+  scopes: {AllOf: ['queue:route:foo', 'queue:route:bar']}
+```
+
+In addition, parameters can be nested objects and accessed with dotted notation.
+Given parameters `task` that is `{extra: {treeherder: {symbol: 'F'}}}`, we can do
+the following:
+
+```js
+  scopes: {AllOf: ['some:scope', 'some:scope:<task.extra.treeherder.symbol>']}
+```
+
+which evaluates to
+
+```js
+  scopes: {AllOf: ['some:scope', 'some:scope:F']}
+```
+
+When you specify scopes required to access an endpoint, by default all of the params
+specified in the `params` section will be substituted in and the expression satisfaction
+will be checked against the client's scopes. If any of the parameters specified in
+your scopes are _not_ in the `params`, this satisfaction check will be deferred and the
+endpoint implementation _must_ check for authorization manually as described below. If
+this check does not occur, taskcluster-lib-api will throw an error for the result of the
+endpoint.
 
 ### Stability Levels
 
@@ -220,30 +257,15 @@ includes some additional security token, its duration should be limited to this
 expiration time to prevent callers from extending their access beyond the
 allowed time.
 
-The `req.satisfies(.., noReply)` method returns `true` if the client satisfies
-one of the scopesets. If the client does not satisfy one of the scopesets, it
-returns `false` and sends an error message unless `noReply` is true. 
+The `req.authorize(params, options)` method returns `true` if the client satisfies
+the endpoint's scope expression. If the client does not satisfy the expression, it
+returns `false` and sends an error message unless `options.noReply` is true.
 
-The first argument to `req.satisfies` can be a scopeset (in disjunctive normal
-form as described above).  Or, it can be an object, in which case the method
-will assume this object is a mapping from scope parameters (`<name>`) to
-values.
-
-If `deferAuth` is set to `true`, then authentication will be postponed to the
-first invocation of `req.satisfies`.  Note that `deferAuth` will not perform
-authorization unless, `req.satisfies({})` is called either without arguments or
-with an object as first argument.  If `deferAuth` is false, then req.params
-will be used as the scope parameters.
-
-Where authorization depends on parameters or the contents of the request, the
-`req.satisfies` method is generally used with `deferAuth: true` in a construct
-like this:
-
-```js
-  if (!req.satisfies({hookGroupId, hookId})) {
-    return;
-  }
-```
+The first argument to `req.authorize` must be an object where the keys are parameters
+to the scope expression defined in the method definition. If any parameters are missing
+when you call this, the check will error unless you pass `options.allowLater`. This is
+only for special cases and should be rarely used. The rules for how the scope expression
+defined in the method is transformed given a set of parameters is described above.
 
 To return a successful result with a JSON body, return `res.reply(result)`.
 The result will be validated against the output schema, and if validation

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "taskcluster-lib-app": "^2.0.3",
     "taskcluster-lib-monitor": "^4.6.3",
     "taskcluster-lib-testing": "^2.0.2",
-    "taskcluster-lib-validate": "^3.0.1",
+    "taskcluster-lib-validate": "^3.0.3",
     "typed-env-config": "^1.1.1"
   },
   "main": "./lib/api.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "promise": "^8.0.1",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.0",
-    "taskcluster-lib-scopes": "^1.8.0",
+    "taskcluster-lib-scopes": "^1.8.1",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "promise": "^8.0.1",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.0",
-    "taskcluster-lib-scopes": "^1.2.0",
+    "taskcluster-lib-scopes": "^1.7.0",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "promise": "^8.0.1",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.0",
-    "taskcluster-lib-scopes": "^1.7.0",
+    "taskcluster-lib-scopes": "^1.8.0",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0"
   },

--- a/src/api.js
+++ b/src/api.js
@@ -519,14 +519,14 @@ var remoteAuthentication = function(options, entry) {
 
         if (missing.length) {
           if (allowLater) {
-            debug(`Not all parameters supplied yet. Deferring authorization due to missing parameters: ${req.missing}`);
+            debug(`Not all parameters supplied yet. Deferring authorization for due to missing parameters: ${missing}`);
             return true;
           }
-          return res.reportInternalError('InternalServerError', [
-            'Not all parameters were supplied to a scope check.',
-            'The call to req.authorize was not allowed to be partially',
-            'applied. Missing parameters: {{missing}}',
-          ].join('\n'), {missing: req.missing});
+          return res.reportInternalError(new Error(`
+            Not all parameters were supplied to a scope check.
+            The call to req.authorize was not allowed to be partially
+            applied. Missing parameters: ${JSON.stringify(missing)}`,
+          ), {missing});
         }
 
         // Test that we have scope intersection, and hence, is authorized

--- a/src/api.js
+++ b/src/api.js
@@ -559,7 +559,6 @@ var remoteAuthentication = function(options, entry) {
         // TODO: log this in a structured format when structured logging is
         // available https://bugzilla.mozilla.org/show_bug.cgi?id=1307271
         authLog(`Authorized ${await req.clientId()} for ${req.method} access to ${req.originalUrl}`);
-        return true;
       };
 
       req.hasAuthed = false;
@@ -569,7 +568,8 @@ var remoteAuthentication = function(options, entry) {
       if (!entry.scopes) {
         req.hasAuthed = true;  // No need to check auth if there are no scopes
         next();
-      } else if (await req.authorize(req.params, {allowLater: true})) {
+      } else {
+        await req.authorize(req.params, {allowLater: true});
         next();
       }
     } catch (err) {

--- a/src/api.js
+++ b/src/api.js
@@ -532,11 +532,7 @@ var remoteAuthentication = function(options, entry) {
         // Test that we have scope intersection, and hence, is authorized
         let authed = !scopeExpression || scopes.satisfiesExpression(result.scopes, scopeExpression);
         req.hasAuthed = true;
-        if (authed) {
-          // TODO: log this in a structured format when structured logging is
-          // available https://bugzilla.mozilla.org/show_bug.cgi?id=1307271
-          authLog(`Authorized ${await req.clientId()} for ${req.method} access to ${req.originalUrl}`);
-        }
+
         if (!authed) {
           let err = new Error('Authorization failed'); // This way instead of subclassing due to babel/babel#3083
           err.name =  'AuthorizationError';
@@ -559,7 +555,11 @@ var remoteAuthentication = function(options, entry) {
           ].join('\n');
           throw err;
         }
-        return authed;
+
+        // TODO: log this in a structured format when structured logging is
+        // available https://bugzilla.mozilla.org/show_bug.cgi?id=1307271
+        authLog(`Authorized ${await req.clientId()} for ${req.method} access to ${req.originalUrl}`);
+        return true;
       };
 
       req.hasAuthed = false;

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,4 @@
 var express       = require('express');
-
 var Debug         = require('debug');
 var Promise       = require('promise');
 var hawk          = require('hawk');
@@ -490,6 +489,10 @@ var remoteAuthentication = function(options, entry) {
           return new Date(result.expires);
         }
         return undefined;
+      };
+
+      req.satisfies = function() {
+        throw new Error('req.satisfies is deprecated! use req.authorize instead');
       };
 
       /**

--- a/src/api.js
+++ b/src/api.js
@@ -522,11 +522,11 @@ var remoteAuthentication = function(options, entry) {
             debug(`Not all parameters supplied yet. Deferring authorization for due to missing parameters: ${missing}`);
             return true;
           }
-          return res.reportInternalError(new Error(`
+          throw new Error(`
             Not all parameters were supplied to a scope check.
             The call to req.authorize was not allowed to be partially
             applied. Missing parameters: ${JSON.stringify(missing)}`,
-          ), {missing});
+          );
         }
 
         // Test that we have scope intersection, and hence, is authorized

--- a/src/api.js
+++ b/src/api.js
@@ -530,7 +530,7 @@ var remoteAuthentication = function(options, entry) {
         }
 
         // Test that we have scope intersection, and hence, is authorized
-        let authed = scopes.satisfiesExpression(result.scopes, scopeExpression);
+        let authed = !scopeExpression || scopes.satisfiesExpression(result.scopes, scopeExpression);
         req.hasAuthed = true;
         if (authed) {
           // TODO: log this in a structured format when structured logging is
@@ -766,8 +766,7 @@ API.prototype.declare = function(options, handler) {
       if (_.isObject(scope) && scope.for && scope.in && scope.each) {
         return 'looping-template-construct';
       } else if (_.isObject(scope) && scope.if && scope.then) {
-        assert(scopes.validExpression(scope.then));
-        return 'conditional-template-construct';
+        return scope.then;
       }
     })));
   }

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -1,3 +1,4 @@
+const scopes = require('taskcluster-lib-scopes');
 const _ = require('lodash');
 
 export const splatParams = (scope, params, missing) => scope.replace(/<([^>]+)>/g, (match, param) => {

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -11,35 +11,35 @@ export const splatParams = (scope, params, missing) => scope.replace(/<([^>]+)>/
 });
 
 export const expandExpressionTemplate = (template, params, missing) => {
-  const key = Object.keys(template)[0];
-  let subexpressions = [];
-  template[key].forEach(scope => {
-    if (typeof scope === 'string') {
-      subexpressions.push(splatParams(scope, params, missing));
-    } else if (_.isObject(scope) && scope.for && scope.in && scope.each) {
-      let subs = _.at(params, scope.in)[0];
-      if (!subs) {
-        missing.push(scope.in);
-        subexpressions.push(scope);
-        return;
-      }
-      subs.forEach(param => {
-        subexpressions.push(splatParams(scope.each.replace(`<${scope.for}>`, param), params, missing));
-      });
-    } else if (_.isObject(scope) && scope.if && scope.then) {
-      const conditional = _.at(params, scope.if)[0];
-      if (conditional === true) {
-        // Only do this if the conditional exists and is literally true
-        subexpressions.push(expandExpressionTemplate(scope.then, params, missing));
-      } else if (conditional === undefined) {
-        // In the case that the conditional is false, do nothing. If it is missing, we say so
-        missing.push(scope.if);
-      } else if (conditional !== false) {
-        throw new error(`conditional values must be booleans! ${scope.if} is a ${typeof scope.if}`);
-      }
-    } else {
-      subexpressions.push(expandExpressionTemplate(scope, params, missing));
+  if (typeof template === 'string') {
+    return splatParams(template, params, missing);
+  } else if (_.isObject(template) && template.for && template.in && template.each) {
+    let subs = _.at(params, template.in)[0];
+    if (!subs) {
+      missing.push(template.in);
+      return;
     }
-  });
-  return {[key]: subexpressions};
+    return subs.map(param => splatParams(template.each.replace(`<${template.for}>`, param), params, missing));
+  } else if (_.isObject(template) && template.if && template.then) {
+    const conditional = _.at(params, template.if)[0];
+    if (conditional === true) {
+      // Only do this if the conditional exists and is literally true
+      return expandExpressionTemplate(template.then, params, missing);
+    } else if (conditional === undefined) {
+      // In the case that the conditional is false, do nothing. If it is missing, we say so
+      missing.push(template.if);
+    } else if (conditional !== false) {
+      throw new error(`conditional values must be booleans! ${template.if} is a ${typeof template.if}`);
+    }
+  } else {
+    const key = Object.keys(template)[0];
+    let subexpressions = [];
+    template[key].forEach(scope => {
+      const results = expandExpressionTemplate(scope, params, missing);
+      if (results) {
+        subexpressions = subexpressions.concat(results);
+      }
+    });
+    return {[key]: subexpressions};
+  }
 };

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -1,0 +1,44 @@
+const _ = require('lodash');
+
+export const splatParams = (scope, params, missing) => scope.replace(/<([^>]+)>/g, (match, param) => {
+  const value = _.at(params, param)[0];
+  if (value !== undefined) {
+    return value;
+  }
+  missing.push(match); // If any are left undefined, we can't be done yet
+  return match;
+});
+
+export const expandExpressionTemplate = (template, params, missing) => {
+  const key = Object.keys(template)[0];
+  let subexpressions = [];
+  template[key].forEach(scope => {
+    if (typeof scope === 'string') {
+      subexpressions.push(splatParams(scope, params, missing));
+    } else if (_.isObject(scope) && scope.for && scope.in && scope.each) {
+      let subs = _.at(params, scope.in)[0];
+      if (!subs) {
+        missing.push(scope.in);
+        subexpressions.push(scope);
+        return;
+      }
+      subs.forEach(param => {
+        subexpressions.push(splatParams(scope.each.replace(`<${scope.for}>`, param), params, missing));
+      });
+    } else if (_.isObject(scope) && scope.if && scope.then) {
+      const conditional = _.at(params, scope.if)[0];
+      if (conditional === true) {
+        // Only do this if the conditional exists and is literally true
+        subexpressions.push(expandExpressionTemplate(scope.then, params, missing));
+      } else if (conditional === undefined) {
+        // In the case that the conditional is false, do nothing. If it is missing, we say so
+        missing.push(scope.if);
+      } else if (conditional !== false) {
+        throw new error(`conditional values must be booleans! ${scope.if} is a ${typeof scope.if}`);
+      }
+    } else {
+      subexpressions.push(expandExpressionTemplate(scope, params, missing));
+    }
+  });
+  return {[key]: subexpressions};
+};

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -1,9 +1,51 @@
 {
-    "$id": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "title": "API Reference File",
     "description": "Reference of methods implemented by API",
     "type": "object",
+    "definitions": {
+      "subExpression": {"type": "array", "items": {"$ref": "#/definitions/scopeExpressionTemplate"}},
+      "scopeExpressionTemplate": {
+        "oneOf": [
+          {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
+          {
+            "type": "object",
+            "properties": {
+              "AnyOf": {"$ref": "#/definitions/subExpression"}
+            },
+            "required": ["AnyOf"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "AllOf": {"$ref": "#/definitions/subExpression"}
+            },
+            "required": ["AllOf"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "if": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
+              "then": {"$ref": "#/definitions/scopeExpressionTemplate"}
+            },
+            "required": ["if", "then"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "for": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
+              "each": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
+              "in": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"}
+            },
+            "required": ["for", "each", "in"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
     "properties": {
         "version": {
             "description": "API reference version",
@@ -106,17 +148,8 @@
                         ]
                     },
                     "scopes": {
-                        "type": "array",
-                        "description": "List of scope-sets of which the client must satisfy at least one of the sets of scopes. Not provided if authentication isn't required.",
-                        "items": {
-                            "type": "array",
-                            "description": "A set of scopes that grants access if all the scopes in the set is satisfied.  Scopes must be composed of printable ASCII characters and spaces.",
-                            "items": {
-                                "type": "string",
-                                "description": "Scope identifier",
-                                "pattern": "^[\\x20-\\x7e]*$"
-                            }
-                        }
+                        "description": "Scope expression template specifying required scopes for a method. Not provided if authentication isn't required.",
+                        "$ref": "#/definitions/scopeExpressionTemplate"
                     },
                     "input": {
                         "type": "string",

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -4,28 +4,34 @@
     "description": "Reference of methods implemented by API",
     "type": "object",
     "definitions": {
-      "subExpression": {"type": "array", "items": {"$ref": "#/definitions/scopeExpressionTemplate"}},
       "scopeExpressionTemplate": {
         "oneOf": [
-          {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
+          {
+            "type": "string",
+            "description": "The most basic element of a scope expression",
+            "pattern": "^[\\x20-\\x7e]*$"
+          },
           {
             "type": "object",
+            "description": "AnyOf objects will evaluate to true if any subexpressions are true",
             "properties": {
-              "AnyOf": {"$ref": "#/definitions/subExpression"}
+              "AnyOf": {"type": "array", "items": {"$ref": "#/definitions/scopeExpressionTemplate"}}
             },
             "required": ["AnyOf"],
             "additionalProperties": false
           },
           {
             "type": "object",
+            "description": "AllOf objects will evaluate to true if all subexpressions are true",
             "properties": {
-              "AllOf": {"$ref": "#/definitions/subExpression"}
+              "AllOf": {"type": "array", "items": {"$ref": "#/definitions/scopeExpressionTemplate"}}
             },
             "required": ["AllOf"],
             "additionalProperties": false
           },
           {
             "type": "object",
+            "description": "if/then objects will replace themselves with the contents of then if the `if` is true",
             "properties": {
               "if": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
               "then": {"$ref": "#/definitions/scopeExpressionTemplate"}
@@ -35,6 +41,7 @@
           },
           {
             "type": "object",
+            "description": "for/each/in objects will replace themselves with an array of basic scopes. They will be flattened into the array this object is a part of.",
             "properties": {
               "for": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},
               "each": {"type": "string", "pattern": "^[\\x20-\\x7e]*$"},

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -57,8 +57,8 @@ suite('api/auth', function() {
     title:        'Test End-Point',
     scopes:       {AllOf: ['service:<param>']},
     description:  'Place we can call to test something',
-  }, function(req, res) {
-    if (req.authorize({
+  }, async function(req, res) {
+    if (await req.authorize({
       param:      'myfolder/resource',
     })) {
       res.status(200).json('OK');
@@ -85,8 +85,8 @@ suite('api/auth', function() {
     title:        'Test End-Point',
     scopes:       {AllOf: [{for: 'scope', in: 'request.scopes', each: '<scope>'}]},
     description:  'Place we can call to test something',
-  }, function(req, res) {
-    if (req.authorize({request: req.body})) {
+  }, async function(req, res) {
+    if (await req.authorize({request: req.body})) {
       return res.status(200).json('OK');
     }
   });
@@ -103,8 +103,8 @@ suite('api/auth', function() {
       {for: 'scope', in: 'task.scopes', each: '<scope>'},
     ]},
     description:  'Place we can call to test something',
-  }, function(req, res) {
-    if (req.authorize({
+  }, async function(req, res) {
+    if (await req.authorize({
       provisionerId:    req.params.provisionerId,
       workerType:       req.params.workerType,
       task:             req.body,
@@ -124,8 +124,8 @@ suite('api/auth', function() {
       {if: 'public', then: {AllOf: []}},
     ]},
     description:  'Place we can call to test something',
-  }, function(req, res) {
-    if (req.authorize({
+  }, async function(req, res) {
+    if (await req.authorize({
       public: req.body.public,
     })) {
       return res.status(200).json('OK');

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -70,11 +70,10 @@ suite('api/auth', function() {
     scopes:       {AllOf: ['service:<param>']},
     description:  'Place we can call to test something',
   }, async function(req, res) {
-    if (await req.authorize({
+    await req.authorize({
       param:      'myfolder/resource',
-    })) {
-      res.status(200).json('OK');
-    }
+    });
+    res.status(200).json('OK');
   });
 
   // Declare a method we can test overriding errors with
@@ -121,9 +120,8 @@ suite('api/auth', function() {
     scopes:       {AllOf: [{for: 'scope', in: 'request.scopes', each: '<scope>'}]},
     description:  'Place we can call to test something',
   }, async function(req, res) {
-    if (await req.authorize({request: req.body})) {
-      return res.status(200).json('OK');
-    }
+    await req.authorize({request: req.body});
+    return res.status(200).json('OK');
   });
 
   // Declare a method we can test with expression authorization again
@@ -139,13 +137,12 @@ suite('api/auth', function() {
     ]},
     description:  'Place we can call to test something',
   }, async function(req, res) {
-    if (await req.authorize({
+    await req.authorize({
       provisionerId:    req.params.provisionerId,
       workerType:       req.params.workerType,
       task:             req.body,
-    })) {
-      return res.status(200).json('OK');
-    }
+    });
+    return res.status(200).json('OK');
   });
 
   // Declare a couple methods we can test with expression utilizing if/then
@@ -160,11 +157,10 @@ suite('api/auth', function() {
     ]},
     description:  'Place we can call to test something',
   }, async function(req, res) {
-    if (await req.authorize({
+    await req.authorize({
       public: req.body.public,
-    })) {
-      return res.status(200).json('OK');
-    }
+    });
+    return res.status(200).json('OK');
   });
   api.declare({
     method:       'get',
@@ -176,11 +172,10 @@ suite('api/auth', function() {
     ]}},
     description:  'Place we can call to test something',
   }, async function(req, res) {
-    if (await req.authorize({
+    await req.authorize({
       private: !req.body.public,
-    })) {
-      return res.status(200).json('OK');
-    }
+    });
+    return res.status(200).json('OK');
   });
 
   // Declare a method we can test with expression utilizing if/then but then forget to auth

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -25,6 +25,18 @@ suite('api/auth', function() {
 
   api.declare({
     method:       'get',
+    route:        '/test-deprecated-satisfies',
+    name:         'testDepSat',
+    title:        'Test End-Point',
+    description:  'Place we can call to test something',
+  }, function(req, res) {
+    if (req.satisfies([])) {
+      res.status(200).json({ok: true});
+    }
+  });
+
+  api.declare({
+    method:       'get',
     route:        '/test-static-scope',
     name:         'testStaticScopes',
     title:        'Test End-Point',
@@ -195,6 +207,21 @@ suite('api/auth', function() {
   teardown(async () => {
     testing.fakeauth.stop();
     await _apiServer.terminate();
+  });
+
+  test('function that still uses satisfies fails', function() {
+    var url = 'http://localhost:23526/test-deprecated-satisfies';
+    return request
+      .get(url)
+      .hawk({
+        id:           'nobody',
+        key:          'test-token',
+        algorithm:    'sha256',
+      })
+      .then(res => assert(false, 'request didn\'t fail'))
+      .catch(function(res) {
+        assert(res.status === 500, 'Request didn\'t fail');
+      });
   });
 
   test('request with static scope', function() {

--- a/test/expressions_test.js
+++ b/test/expressions_test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const expressions = require('../lib/expressions');
 
-suite('expression success', function() {
+suite('expression expansion success', function() {
 
   function scenario(expr, params, result, shouldFail=false) {
     return () => {
@@ -53,7 +53,7 @@ suite('expression success', function() {
   });
 });
 
-suite('expression missing', function() {
+suite('expression expansion missing params', function() {
 
   function scenario(expr, params, shouldBeMissing) {
     return () => {

--- a/test/expressions_test.js
+++ b/test/expressions_test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const expressions = require('../lib/expressions');
+
+suite('expression success', function() {
+
+  function scenario(expr, params, result, shouldFail=false) {
+    return () => {
+      let missing = [];
+      try {
+        assert.deepEqual(expressions.expandExpressionTemplate(expr, params, missing), result);
+      } catch (err) {
+        if (shouldFail) {
+          return;
+        }
+        throw err;
+      }
+      if (shouldFail) {
+        throw new Error('Should have failed!');
+      }
+    };
+  }
+
+  // These should succeed
+  [
+    [{AnyOf: []}, {}, {AnyOf: []}],
+    [{AllOf: []}, {}, {AllOf: []}],
+    [{AllOf: ['abc:<foo>']}, {foo: 'hi'}, {AllOf: ['abc:hi']}],
+    [{AllOf: ['abc:<foo>:<bar>']}, {foo: 'hi', bar: 'bye'}, {AllOf: ['abc:hi:bye']}],
+    [{AllOf: ['abc:<foo>:<bar>:<baz>']}, {foo: 'hi', bar: 'bye', baz: 'bing'}, {AllOf: ['abc:hi:bye:bing']}],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: false}, undefined],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: true}, {AllOf: ['bar']}],
+    [{if: 'foo', then: {AllOf: ['bar:<baz>']}}, {foo: true, baz: 'hi'}, {AllOf: ['bar:hi']}],
+    [{AllOf: [{for: 'foo', in: 'bar', each: 'aa:<foo>'}]}, {bar: ['aaa', 'bbb']}, {AllOf: ['aa:aaa', 'aa:bbb']}],
+    [
+      {AllOf: [{for: 'foo', in: 'bar', each: 'aa:<foo>:<b>'}]},
+      {bar: ['aaa', 'bbb'], b: 'q'},
+      {AllOf: ['aa:aaa:q', 'aa:bbb:q']}],
+  ].map(([e, p, r]) => {
+    test(`${JSON.stringify(e)} with ${JSON.stringify(p)} renders correctly`, scenario(e, p, r));
+  });
+
+  // These should fail
+  [
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: 'abc'}],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: 0}],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: 1}],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: 1.4}],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {foo: new Date()}],
+    [{AllOf: [{for: 'foo', in: 'bar', each: 'aa:<foo>'}]}, {bar: 'a'}],
+    [{AllOf: [{for: 'foo', in: 'bar', each: 'aa:<fox>'}]}, {bar: ['a']}],
+  ].map(([e, p]) => {
+    test(`${JSON.stringify(e)} with ${JSON.stringify(p)} should fail`, scenario(e, p, null, 'fail!'));
+  });
+});
+
+suite('expression missing', function() {
+
+  function scenario(expr, params, shouldBeMissing) {
+    return () => {
+      let missing = [];
+      expressions.expandExpressionTemplate(expr, params, missing);
+      assert.deepEqual(shouldBeMissing, missing);
+    };
+  }
+
+  [
+    [{AnyOf: ['abc:<foo>']}, {}, ['<foo>']],
+    [{AnyOf: ['abc:<foo>']}, {bar: 'a'}, ['<foo>']],
+    [{AnyOf: ['abc:<foo>', '<bar>']}, {}, ['<foo>', '<bar>']],
+    [{AnyOf: []}, {}, []],
+    [{AnyOf: ['abc:<foo>:<bar>']}, {}, ['<foo>', '<bar>']],
+    [{if: 'foo', then: {AllOf: ['bar']}}, {}, ['foo']],
+    [{AllOf: [{for: 'foo', in: 'bar', each: 'aa:<foo>'}]}, {}, ['bar']],
+    [{AllOf: [{for: 'foo', in: 'bar', each: 'aa:<foo>:<baz>'}]}, {bar: ['a']}, ['<baz>']],
+  ].map(([e, p, m]) => {
+    test(`${JSON.stringify(e)} with ${JSON.stringify(p)} is missing ${JSON.stringify(m)}`, scenario(e, p, m));
+  });
+});

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -24,11 +24,79 @@ suite('api/publish', function() {
     // Declare a simple method
     api.declare({
       method:       'get',
-      route:        '/test',
+      route:        '/test0',
       name:         'test',
       title:        'Test End-Point',
       description:  'Place we can call to test something',
       stability:    subject.stability.stable,
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+
+    // Declare some methods with some fun scopes
+    api.declare({
+      method:       'get',
+      route:        '/test1',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {AllOf: ['foo:bar']},
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+    api.declare({
+      method:       'get',
+      route:        '/test2',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {AnyOf: ['foo:bar']},
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+    api.declare({
+      method:       'get',
+      route:        '/test3',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {if: 'not_public', then: {AllOf: ['foo:bar']}},
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+    api.declare({
+      method:       'get',
+      route:        '/test4',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {AllOf: [{for: 'foo', in: 'whatever', each: 'bar:<foo>'}]},
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+    api.declare({
+      method:       'get',
+      route:        '/test4',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {AllOf: [{for: 'foo', in: 'whatever', each: 'bar:<foo>'}]},
+    }, function(req, res) {
+      res.send(200, 'Hello World');
+    });
+    api.declare({
+      method:       'get',
+      route:        '/test3',
+      name:         'test',
+      title:        'Test End-Point',
+      description:  'Place we can call to test something',
+      stability:    subject.stability.stable,
+      scopes:       {if: 'not_public', then: {AllOf: ['abc', {AnyOf: ['e']}, {for: 'a', in: 'b', each: 'c'}]}},
     }, function(req, res) {
       res.send(200, 'Hello World');
     });
@@ -49,7 +117,7 @@ suite('api/publish', function() {
     }).then(function(res) {
       var reference = JSON.parse(res.Body);
       assert(reference.entries, 'Missing entries');
-      assert(reference.entries.length == 2, 'Should have two entries');
+      assert.equal(reference.entries.length, 8);
       assert(reference.title, 'Missing title');
     });
   });

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -32,7 +32,7 @@ suite('api/route', function() {
         title:        'Test',
         description:  'Test',
       }, function(req, res) {});
-    }, /array of arrays of strings/);
+    }, /Scope expressions must be objects/);
   });
 
   test('array of string scope rejected', function() {
@@ -45,19 +45,41 @@ suite('api/route', function() {
         title:        'Test',
         description:  'Test',
       }, function(req, res) {});
-    }, /array of arrays of strings/);
+    }, /Scope expressions must be objects/);
   });
 
-  test('array of arrays of objects scope rejected', function() {
+  test('array of arrays of scope rejected', function() {
     assert.throws(function() {
       api.declare({
         method:       'get',
         route:        '/test/:myparam',
-        scopes:       [[{}]],
+        scopes:       [[]],
         name:         'testEP',
         title:        'Test',
         description:  'Test',
       }, function(req, res) {});
-    }, /array of arrays of strings/);
+    }, /Scope expressions must be objects/);
+  });
+
+  test('scope expression not rejected', function() {
+    api.declare({
+      method:       'get',
+      route:        '/test/:myparam',
+      scopes:       {AnyOf: ['something']},
+      name:         'testEP',
+      title:        'Test',
+      description:  'Test',
+    }, function(req, res) {});
+  });
+
+  test('scope expression with looping template not rejected', function() {
+    api.declare({
+      method:       'get',
+      route:        '/test/:myparam',
+      scopes:       {AnyOf: [{for: 'foo', in: 'bar', each: '<foo>'}]},
+      name:         'testEP',
+      title:        'Test',
+      description:  'Test',
+    }, function(req, res) {});
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,6 +2755,22 @@ taskcluster-lib-validate@^3.0.1:
     url-join "^2.0.2"
     walk "^2.3.9"
 
+taskcluster-lib-validate@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-validate/-/taskcluster-lib-validate-3.0.3.tgz#3b09ccda1a205e728009bafb60f2eb0a11e10a85"
+  dependencies:
+    ajv "^5.3.0"
+    app-root-dir "^1.0.2"
+    aws-sdk "^2.142.0"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    js-yaml "^3.10.0"
+    lodash "^4.5.1"
+    promise "^8.0.1"
+    rimraf "^2.6.2"
+    url-join "^2.0.2"
+    walk "^2.3.9"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,9 +2712,9 @@ taskcluster-lib-monitor@^4.6.3:
     taskcluster-client "^1.0.1"
     usage "^0.7.1"
 
-taskcluster-lib-scopes@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.7.0.tgz#e7104cb1b03acd05094dadfa15c7c732428c6afd"
+taskcluster-lib-scopes@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.8.0.tgz#a3dadd33ea1d52b8fac2673076d6e4ccb885fb02"
   dependencies:
     babel-runtime "^6.26.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,9 +2712,9 @@ taskcluster-lib-monitor@^4.6.3:
     taskcluster-client "^1.0.1"
     usage "^0.7.1"
 
-taskcluster-lib-scopes@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.8.0.tgz#a3dadd33ea1d52b8fac2673076d6e4ccb885fb02"
+taskcluster-lib-scopes@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.8.1.tgz#e85162a0435a2fd187cdbf8f5c25a96271127be7"
   dependencies:
     babel-runtime "^6.26.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,9 +2712,9 @@ taskcluster-lib-monitor@^4.6.3:
     taskcluster-client "^1.0.1"
     usage "^0.7.1"
 
-taskcluster-lib-scopes@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.2.0.tgz#c3409a34e6627b90a09be3b48c139ee58dabff3b"
+taskcluster-lib-scopes@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.7.0.tgz#e7104cb1b03acd05094dadfa15c7c732428c6afd"
   dependencies:
     babel-runtime "^6.26.0"
 


### PR DESCRIPTION
This is for taskcluster/taskcluster-rfcs#23. After this work we should be able to take a few more steps and then get to the world where authorization takes place in taskcluster-auth as well.

This PR presents an implementation of the scope expression templates. I think we're fairly (~78%) confident that this will allow us to cover all of the current use cases of `req.satisfies`. I think my code is a bit messy at the moment, I may take a bit to go back over it and see if I can simplify. Also please feel free to simplify it for me!

In addition if while reviewing you can think of more test cases, please throw them my way and we can add them.

I'm 90% sure you will find huge flaws in my logic because that is the normal case for these reviews, but please be careful and harsh since this is important to get right!
  