### PR TITLE
Added titles to the various scope expression template forms

### DIFF
--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -7,11 +7,13 @@
       "scopeExpressionTemplate": {
         "oneOf": [
           {
+            "title": "Required Scope",
             "type": "string",
             "description": "The most basic element of a scope expression",
             "pattern": "^[\\x20-\\x7e]*$"
           },
           {
+            "title": "Any Of",
             "type": "object",
             "description": "AnyOf objects will evaluate to true if any subexpressions are true",
             "properties": {
@@ -21,6 +23,7 @@
             "additionalProperties": false
           },
           {
+            "title": "All Of",
             "type": "object",
             "description": "AllOf objects will evaluate to true if all subexpressions are true",
             "properties": {
@@ -30,6 +33,7 @@
             "additionalProperties": false
           },
           {
+            "title": "If/Then",
             "type": "object",
             "description": "if/then objects will replace themselves with the contents of then if the `if` is true",
             "properties": {
@@ -40,6 +44,7 @@
             "additionalProperties": false
           },
           {
+            "title": "For/Each/In",
             "type": "object",
             "description": "for/each/in objects will replace themselves with an array of basic scopes. They will be flattened into the array this object is a part of.",
             "properties": {

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -171,11 +171,13 @@
                     "output": {
                         "oneOf": [
                             {
+                                "title": "Output Schema",
                                 "type": "string",
                                 "format": "uri",
                                 "description": "JSON schema for output, if output is provided otherwise not present."
                             },
                             {
+                                "title": "Blob",
                                 "type": "string",
                                 "const": "blob",
                                 "description": "Output kind if not JSON matching a specific schema."


### PR DESCRIPTION
Hey Brian,

Adding these titles will make the output of the following command much nicer. This is useful because the taskcluster client generation reads the API references, so we generate this code from the API references schema in order to process the references (in other words, this generated code below gets checked into the code generator of `taskcluster-client-go`).

The change this makes is it gives the types that represent the different scope expression template forms distinct names.

Thanks!
Pete

```
$ echo 'https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json' | jsonschema2go -o model
// This source code file is AUTO-GENERATED by github.com/taskcluster/jsonschema2go

package model

import (
	"encoding/json"
	"errors"
)

type (
	// Reference of methods implemented by API
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#
	APIReferenceFile struct {

		// Link to schema for this reference. That is a link to this very document. Typically used to identify what kind of reference this file is.
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/$schema
		Schema string `json:"$schema"`

		// BaseUrl for all _routes_ described in this document
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/baseUrl
		BaseURL string `json:"baseUrl"`

		// API description in markdown
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/description
		Description string `json:"description"`

		// Array of methods in this reference
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries
		Entries []struct {

			// Arguments from `route` that must be replaced, they'll appear wrapped in brackets inside `route`.
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/args
			Args []string `json:"args"`

			// Description (ie. documentation) for the API entry
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/description
			Description string `json:"description"`

			// JSON schema for input, if input is taken otherwise not present.
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/input
			Input string `json:"input,omitempty"`

			// HTTP method (verb) used to access the function
			//
			// Possible values:
			//   * "get"
			//   * "post"
			//   * "put"
			//   * "head"
			//   * "delete"
			//   * "options"
			//   * "trace"
			//   * "copy"
			//   * "lock"
			//   * "mkcol"
			//   * "move"
			//   * "purge"
			//   * "propfind"
			//   * "proppatch"
			//   * "unlock"
			//   * "report"
			//   * "mkactivity"
			//   * "checkout"
			//   * "merge"
			//   * "m-search"
			//   * "notify"
			//   * "subscribe"
			//   * "unsubscribe"
			//   * "patch"
			//   * "search"
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/method
			Method string `json:"method"`

			// Name of the `function` this is a stable identifier for use in auto-generated client libraries
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/name
			Name string `json:"name"`

			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/output
			Output json.RawMessage `json:"output,omitempty"`

			// List of accepted query-string parameters, these are always optional.
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/query
			Query []string `json:"query,omitempty"`

			// Route for the call, note that arguments wrapped with brackets, like `/v1/user/<userId>/` must be replaced. And the route must be appended to the `baseUrl`
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/route
			Route string `json:"route"`

			// Scope expression template specifying required scopes for a method. Not provided if authentication isn't required.
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/scopes
			Scopes ScopeExpressionTemplate `json:"scopes,omitempty"`

			// Stability level of the API
			//
			// Possible values:
			//   * "deprecated"
			//   * "experimental"
			//   * "stable"
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/stability
			Stability string `json:"stability"`

			// Title of API entry
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/title
			Title string `json:"title"`

			// Type of entry, currently only `function`.
			//
			// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/type
			Type string `json:"type"`
		} `json:"entries"`

		// API title in markdown
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/title
		Title string `json:"title"`

		// API reference version
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/version
		Version json.RawMessage `json:"version"`
	}

	// AllOf objects will evaluate to true if all subexpressions are true
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[2]
	AllOf struct {

		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[2]/properties/AllOf
		AllOf []ScopeExpressionTemplate `json:"AllOf"`
	}

	// AnyOf objects will evaluate to true if any subexpressions are true
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[1]
	AnyOf struct {

		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[1]/properties/AnyOf
		AnyOf []ScopeExpressionTemplate `json:"AnyOf"`
	}

	// Output kind if not JSON matching a specific schema.
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/output/oneOf[1]
	Blob string

	// for/each/in objects will replace themselves with an array of basic scopes. They will be flattened into the array this object is a part of.
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[4]
	ForEachIn struct {

		// Syntax:     ^[\x20-\x7e]*$
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[4]/properties/each
		Each string `json:"each"`

		// Syntax:     ^[\x20-\x7e]*$
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[4]/properties/for
		For string `json:"for"`

		// Syntax:     ^[\x20-\x7e]*$
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[4]/properties/in
		In string `json:"in"`
	}

	// if/then objects will replace themselves with the contents of then if the `if` is true
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[3]
	IfThen struct {

		// Syntax:     ^[\x20-\x7e]*$
		//
		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[3]/properties/if
		If string `json:"if"`

		// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[3]/properties/then
		Then ScopeExpressionTemplate `json:"then"`
	}

	// JSON schema for output, if output is provided otherwise not present.
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/properties/entries/items/properties/output/oneOf[0]
	OutputSchema string

	// The most basic element of a scope expression
	//
	// Syntax:     ^[\x20-\x7e]*$
	//
	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate/oneOf[0]
	RequiredScope string

	// See https://raw.githubusercontent.com/taskcluster/taskcluster-lib-api/name-scope-expression-forms/src/schemas/api-reference.json#/definitions/scopeExpressionTemplate
	ScopeExpressionTemplate json.RawMessage
)

// MarshalJSON calls json.RawMessage method of the same name. Required since
// ScopeExpressionTemplate is of type json.RawMessage...
func (this *ScopeExpressionTemplate) MarshalJSON() ([]byte, error) {
	x := json.RawMessage(*this)
	return (&x).MarshalJSON()
}

// UnmarshalJSON is a copy of the json.RawMessage implementation.
func (this *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
	if this == nil {
		return errors.New("ScopeExpressionTemplate: UnmarshalJSON on nil pointer")
	}
	*this = append((*this)[0:0], data...)
	return nil
}
```