### PR TITLE
I made a bug in the changes when I tweaked things. I totally got the parameter substitution wrong...

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,5 +1,5 @@
 let uuid = require('uuid');
-let debug = require('debug')('base:api');
+let debug = require('debug')('api:errors');
 let _ = require('lodash');
 
 const ERROR_CODES = {


### PR DESCRIPTION
On the plus side we now only have the `details` that we explicitly want to send
as parameters... Before we would get `message` and `code` this way too.

Anyways, this should be a non-controversial fix.