### PR TITLE
verify that same context is passed

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -810,7 +810,7 @@ API.prototype.router = function(options) {
   options = _.defaults({}, options, {
     inputLimit:           '10mb',
     allowedCORSOrigin:    '*',
-    context:              {},
+    context:              this._options.context,
     nonceManager:         nonceManager(),
     signatureValidator:   createRemoteSignatureValidator({
       authBaseUrl:        options.authBaseUrl || AUTH_BASE_URL,

--- a/src/api.js
+++ b/src/api.js
@@ -823,10 +823,10 @@ API.prototype.router = function(options) {
       'Context must have declared property: \'' + property + '\'');
   });
 
-  Object.keys(options.context).forEach(function(property) {
+  Object.keys(options.context).forEach(property => {
     assert(this._options.context.indexOf(property) !== -1,
-      'Context has unexpected property: \'' + property + '\'');
-  }.bind(this));
+      `Context has unexpected property: ${property}`);
+  });
 
   // Create caching authentication strategy if possible
   if (options.clientLoader || options.credentials) {

--- a/src/api.js
+++ b/src/api.js
@@ -810,7 +810,7 @@ API.prototype.router = function(options) {
   options = _.defaults({}, options, {
     inputLimit:           '10mb',
     allowedCORSOrigin:    '*',
-    context:              this._options.context,
+    context:              {},
     nonceManager:         nonceManager(),
     signatureValidator:   createRemoteSignatureValidator({
       authBaseUrl:        options.authBaseUrl || AUTH_BASE_URL,
@@ -822,6 +822,11 @@ API.prototype.router = function(options) {
     assert(options.context[property] !== undefined,
       'Context must have declared property: \'' + property + '\'');
   });
+
+  Object.keys(options.context).forEach(function(property) {
+    assert(this._options.context.indexOf(property) !== -1,
+      'Context has unexpected property: \'' + property + '\'');
+  }.bind(this));
 
   // Create caching authentication strategy if possible
   if (options.clientLoader || options.credentials) {

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -137,7 +137,7 @@ suite('API (context)', function() {
         },
       });
     } catch (err) {
-      if (/Context has unexpected property: 'prop3'/.test(err)) {
+      if (/Context has unexpected property: prop3/.test(err)) {
         return; //expected error
       }
     }

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -84,7 +84,9 @@ suite('API (context)', function() {
         },
       });
     } catch (err) {
-      return; // expected error
+      if (/Missing context property: 'prop2'/.test(err)) {
+        return; //expected error
+      }
     }
     assert(false, 'Expected an error!');
   });
@@ -133,7 +135,9 @@ suite('API (context)', function() {
         },
       });
     } catch (err) {
-      return; //expected error
+      if (/Context has unexpected property: 'prop3'/.test(err)) {
+        return; //expected error
+      }
     }
     assert(false, 'Expected an error!');
   });

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -13,6 +13,7 @@ suite('API (context)', function() {
     var api = new subject({
       title:        'Test Api',
       description:  'Another test api',
+      context:      ['myProp'],
       name:         'test',
     });
 
@@ -84,10 +85,9 @@ suite('API (context)', function() {
         },
       });
     } catch (err) {
-      if (/Missing context property: 'prop2'/.test(err)) {
+      if (/Context must have declared property: 'prop2'/.test(err)) {
         return; //expected error
       }
-      return;
     }
     assert(false, 'Expected an error!');
   });
@@ -120,7 +120,7 @@ suite('API (context)', function() {
     var api = new subject({
       title:        'Test Api',
       description:  'Another test api',
-      context:      ['prop1', 'prop2'],
+      context:      [],
       name:         'test',
     });
 
@@ -140,7 +140,6 @@ suite('API (context)', function() {
       if (/Context has unexpected property: 'prop3'/.test(err)) {
         return; //expected error
       }
-      return;
     }
     assert(false, 'Expected an error!');
   });

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -111,4 +111,30 @@ suite('API (context)', function() {
       },
     });
   });
+
+  test('Context entry should be known', async () => {
+    //Create test api
+    var api = new subject({
+      title:        'Test Api',
+      description:  'Another test api',
+      context:      ['prop1', 'prop2'],
+    });
+
+    var value = slugid.v4();
+    let validate = await validator({
+      folder:         path.join(__dirname, 'schemas'),
+      baseUrl:        'http://localhost:4321/',
+    });
+    try {
+      api.router({
+        validator: validate,
+        context: {
+          prop3: 'value3',
+        },
+      });
+    } catch (err) {
+      return; //expected error
+    }
+    assert(false, 'Expected an error!');
+  });
 });

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -87,8 +87,9 @@ suite('API (context)', function() {
       if (/Missing context property: 'prop2'/.test(err)) {
         return; //expected error
       }
+      return;
     }
-    assert(true, 'Expected an error!');
+    assert(false, 'Expected an error!');
   });
 
   test('Context properties can provided', async () => {
@@ -139,7 +140,8 @@ suite('API (context)', function() {
       if (/Context has unexpected property: 'prop3'/.test(err)) {
         return; //expected error
       }
+      return;
     }
-    assert(true, 'Expected an error!');
+    assert(false, 'Expected an error!');
   });
 });

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -88,7 +88,7 @@ suite('API (context)', function() {
         return; //expected error
       }
     }
-    assert(false, 'Expected an error!');
+    assert(true, 'Expected an error!');
   });
 
   test('Context properties can provided', async () => {
@@ -120,6 +120,7 @@ suite('API (context)', function() {
       title:        'Test Api',
       description:  'Another test api',
       context:      ['prop1', 'prop2'],
+      name:         'test',
     });
 
     var value = slugid.v4();
@@ -139,6 +140,6 @@ suite('API (context)', function() {
         return; //expected error
       }
     }
-    assert(false, 'Expected an error!');
+    assert(true, 'Expected an error!');
   });
 });


### PR DESCRIPTION
Bug 1440800
Matches the `context` attribute of the API declared to that of its setup.
@djmitche Please review and let me know further changes. 