### PR TITLE
Add a "name" to the api for references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ let API = require('taskcluster-lib-api');
 let api = new API({
   // Title and description for docs
   title: 'My API',
+  name: 'my-api', // Must match /^[a-zA-Z][a-zA-Z0-9_-]*$/
   description: [
     "Long string with **markdown** support, used for writing docs",
     "typically written using [].join('\n') to allow for long strings"
@@ -75,6 +76,8 @@ The available options are:
 
  * `title` (required) - the title of the API (the microservice name)
  * `description` (required) - a description of the service, treated as markdown
+ * `name` (required) - a simple name for the service that will become part of a url
+   This must match the regex `/^[a-zA-Z][a-zA-Z0-9_-]*$/`
  * `schemaPrefix` - the prefix for the schema definitions for this service
  * `params` - patterns for URL parameters that apply to all methods (see below)
  * `context` - a list of context entries that must be passed to `api.setup`.  Each

--- a/src/api.js
+++ b/src/api.js
@@ -644,9 +644,10 @@ var handle = function(handler, context, name) {
  * API.
  */
 var API = function(options) {
-  ['title', 'description'].forEach(function(key) {
+  ['title', 'description', 'name'].forEach(function(key) {
     assert(options[key], 'Option \'' + key + '\' must be provided');
   });
+  assert(/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(options.name), `api name "${options.name}" is not valid`);
   this._options = _.defaults({
     errorCodes: _.defaults({}, options.errorCodes || {}, errors.ERROR_CODES),
   }, options, {
@@ -956,15 +957,15 @@ const cleanRouteAndParams = (route) => {
  * }
  */
 API.prototype.reference = function(options) {
-  assert(options,         'Options is required');
+  assert(options, '\'Options\' is required');
   assert(options.baseUrl, 'A \'baseUrl\' must be provided');
   var reference = {
     version:            0,
-    $schema:          'http://schemas.taskcluster.net/base/v1/' +
-                        'api-reference.json#',
+    $schema:            'http://schemas.taskcluster.net/base/v1/api-reference.json#',
     title:              this._options.title,
     description:        this._options.description,
     baseUrl:            options.baseUrl,
+    name:               this._options.name,
     entries: _.concat(this._entries, [ping]).filter(entry => !entry.noPublish).map(function(entry) {
       const [route, params] = cleanRouteAndParams(entry.route);
       var retval = {
@@ -1056,9 +1057,9 @@ API.prototype.publish = function(options) {
  *   validator:           new base.validator()      // JSON schema validator
  *   nonceManager:        function(nonce, ts, cb) { // Check for replay attack
  *   authBaseUrl:         'http://auth.example.net' // BaseUrl for auth server
- *   publish:             true,                    // Publish API reference
- *   baseUrl:             'https://example.com/v1' // URL under which routes are mounted
- *   referencePrefix:     'queue/v1/api.json'      // Prefix within S3 bucket
+ *   publish:             true,                     // Publish API reference
+ *   baseUrl:             'https://example.com/v1'  // URL under which routes are mounted
+ *   referencePrefix:     'queue/v1/api.json'       // Prefix within S3 bucket
  *   referenceBucket:     'reference.taskcluster.net',
  *   aws: {               // AWS credentials and region
  *    accessKeyId:        '...',

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -87,6 +87,13 @@
             "type": "string",
             "format": "uri"
         },
+        "name": {
+            "description": "Name of service for automation. Will be consumed by client generators to produce URLs",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 22,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+        },
         "entries": {
             "type": "array",
             "title": "Entries",
@@ -224,6 +231,7 @@
         "title",
         "description",
         "baseUrl",
+        "name",
         "entries"
     ]
 }

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -22,6 +22,7 @@ suite('api/auth', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Another test api',
+    name:         'test',
   });
 
   // Create a mock authentication server

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -13,6 +13,7 @@ suite('API (context)', function() {
     var api = new subject({
       title:        'Test Api',
       description:  'Another test api',
+      name:         'test',
     });
 
     api.declare({
@@ -67,6 +68,7 @@ suite('API (context)', function() {
       title:        'Test Api',
       description:  'Another test api',
       context:      ['prop1', 'prop2'],
+      name:         'test',
     });
 
     var value = slugid.v4();
@@ -93,6 +95,7 @@ suite('API (context)', function() {
       title:        'Test Api',
       description:  'Another test api',
       context:      ['prop1', 'prop2'],
+      name:         'test',
     });
 
     var value = slugid.v4();

--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -10,7 +10,8 @@ suite('api/errors', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Yet another test api',
-    errorCodes: {TooManyFoos: 472},
+    errorCodes:   {TooManyFoos: 472},
+    name:         'test',
   });
 
   // Create a mock authentication server

--- a/test/publish_test.js
+++ b/test/publish_test.js
@@ -19,6 +19,7 @@ suite('api/publish', function() {
     var api = new subject({
       title:        'Test Api',
       description:  'Another test api',
+      name:         'test',
     });
 
     // Declare a simple method

--- a/test/responsetimer_test.js
+++ b/test/responsetimer_test.js
@@ -10,6 +10,7 @@ suite('api/responsetimer', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Another test api',
+    name:         'test',
   });
 
   api.declare({

--- a/test/route_test.js
+++ b/test/route_test.js
@@ -10,6 +10,7 @@ suite('api/route', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Another test api',
+    name:         'test',
     params: {
       taskId:     /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/,
     },

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -13,6 +13,7 @@ suite('api/schemaPrefix', function() {
     title:        'Test Api',
     description:  'Another test api',
     schemaPrefix: 'http://localhost:4321/',
+    name:         'test',
   });
 
   // Declare a method we can test input with

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -9,6 +9,7 @@ suite('api/route', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Another test api',
+    name:         'test',
   });
 
   test('no scopes is OK', function() {

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -10,6 +10,7 @@ suite('api/validate', function() {
   var api = new subject({
     title:        'Test Api',
     description:  'Another test api',
+    name:         'test',
   });
 
   // Declare a method we can test input with


### PR DESCRIPTION
This will allow the clients to figure out the url to access without inferring it from the baseUrl we currently provide. I also get the feeling that this could be used to reduce the amount of arguments we need to pass to api at instantiation and definition in general if someone took a look.