### PR TITLE
Bug 1449848 - escape markdown in errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,13 @@ only for very specific conditions that the API library detects):
 
 In any case, the `messagePattern` and details are combined to produce an error
 message.  Strings surrounded by `{{..}}` in `messagepattern` are used as keys
-into `details`, with the result being JSON-encoded.  For example:
+into `details`, with the result being JSON-encoded if it is not a simple
+string.  For example:
 
 ```js
 res.reportError(
   'TooManyFoos',
-  'You can only have 3 foos.  These foos already exist:\n{{foos}}',
+  'You can only have 3 foos.  These foos already exist:\n```\n{{foos}}\n```',
   {foos: foomanager.foos(request.fooId)});
 ```
 
@@ -332,11 +333,13 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
   "message": [
     'You can only have 3 foos.',
     'These foos already exist:',
+    '```',
     '[',
     '  1,',
     '  2,',
     '  3',
     ']',
+    '```,
     '----',
     'method:     toomanyfoos',
     'errorCode:  TooManyFoos',
@@ -351,6 +354,9 @@ The resulting HTTP response will have a JSON body containing (whitespace adjuste
   },
 }
 ```
+
+Note that substituted values are escaped to avoid unexpected interpretation as
+markdown.
 
 The request payload is provided in `requestInfo`, so there is no need to
 reproduce its contents within the error message.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-runtime": "^6.26.0",
     "body-parser": "1.18.2",
     "debug": "^3.1.0",
+    "escape-markdown": "^1.0.4",
     "express": "4.16.2",
     "hawk": "6.0.2",
     "lodash": "^4.15.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,7 @@
 let uuid = require('uuid');
 let debug = require('debug')('api:errors');
 let _ = require('lodash');
+let escapeMarkdown = require('escape-markdown');
 
 const ERROR_CODES = {
   MalformedPayload:         400,  // Only for JSON.parse() errors
@@ -62,6 +63,8 @@ let BuildReportErrorMethod = (method, errorCodes, monitor, cleanPayload) => {
         if (typeof value !== 'string') {
           return JSON.stringify(value, null, 2);
         }
+        // escape the substituted value, so that the markdown rendering cannot be abused
+        value = escapeMarkdown(value);
         return value;
       }) + [
           '\n----',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,6 +1085,10 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
+escape-markdown@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/escape-markdown/-/escape-markdown-1.0.4.tgz#752d74bc7ae3fb0b7c684ead26aab4e5a78c4ff7"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
This prevents interpretation of user-defined input as Markdown when
displaying error messages.