### PR TITLE
prevent method declaration with duplicate name

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -789,13 +789,10 @@ API.prototype.declare = function(options, handler) {
   if (this._entries.filter(entry => entry.route == options.route && entry.method == options.method).length > 0) {
     throw new Error('Identical route and method declaration.');
   }
-  if (this._entries.map(a => a.name).some(function(element) {
-    return element == options.name;
-  })) {
+  if (this._entries.some(entry => entry.name === options.name)) {
     throw new Error('This function has already been declared.');
-  } else {
-    this._entries.push(options);
   }
+  this._entries.push(options);
 };
 
 /**

--- a/src/api.js
+++ b/src/api.js
@@ -789,7 +789,19 @@ API.prototype.declare = function(options, handler) {
   if (this._entries.filter(entry => entry.route == options.route && entry.method == options.method).length > 0) {
     throw new Error('Identical route and method declaration.');
   }
-  this._entries.push(options);
+  var testArray = this._entries.map(a => a.name);
+  var length = testArray.length;
+  var isDuplicate = 0;
+  for (var i = 0; i < length; i++) {
+    if (testArray[i] == options.name) {
+      isDuplicate++;
+    }
+  }
+  if (isDuplicate) {
+    throw new Error('This function has already been declared.');
+  } else {
+    this._entries.push(options);
+  }
 };
 
 /**

--- a/src/api.js
+++ b/src/api.js
@@ -789,15 +789,9 @@ API.prototype.declare = function(options, handler) {
   if (this._entries.filter(entry => entry.route == options.route && entry.method == options.method).length > 0) {
     throw new Error('Identical route and method declaration.');
   }
-  var testArray = this._entries.map(a => a.name);
-  var length = testArray.length;
-  var isDuplicate = 0;
-  for (var i = 0; i < length; i++) {
-    if (testArray[i] == options.name) {
-      isDuplicate++;
-    }
-  }
-  if (isDuplicate) {
+  if (this._entries.map(a => a.name).some(function(element) {
+    return element == options.name;
+  })) {
     throw new Error('This function has already been declared.');
   } else {
     this._entries.push(options);

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -63,12 +63,12 @@ suite('api/auth', function() {
     await _apiServer.terminate();
   });
 
-  const testEndpoint = ({method, route, scopes = null, handler, handlerBuilder, tests}) => {
+  const testEndpoint = ({method, route, name, scopes = null, handler, handlerBuilder, tests}) => {
     let sideEffects = {};
     api.declare({
       method,
       route,
-      name: 'placeholder',
+      name,
       title: 'placeholder',
       description: 'placeholder',
       scopes,
@@ -108,6 +108,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route:  '/test-deprecated-satisfies',
+    name: 'testDeprecatedSatisfies',
     handler: (req, res) => {
       if (req.satisfies([])) {
         res.status(200).json({ok: true});
@@ -126,6 +127,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route:  '/test-static-scope',
+    name: 'testStaticScope',
     scopes: {AllOf: ['service:magic']},
     handler: (req, res) => {
       res.status(200).json({ok: true});
@@ -182,6 +184,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/scopes',
+    name: 'scopes',
     scopes: {AllOf: ['service:magic']},
     handler: async (req, res) => {
       res.status(200).json({
@@ -210,6 +213,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-scopes',
+    name: 'testScopes',
     scopes: {AllOf: ['service:<param>']},
     handler: async (req, res) => {
       await req.authorize({
@@ -235,6 +239,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-scopes-authorize-twice',
+    name: 'testScopesAuthorizeTwice',
     scopes: {AllOf: ['service:<param>']},
     handler: async (req, res) => {
       await req.authorize({
@@ -263,6 +268,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/crash-override',
+    name: 'crashOverride',
     scopes: {AllOf: ['service:<param>']},
     handler: async (req, res) => {
       try {
@@ -291,6 +297,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-no-auth',
+    name: 'testNoAuth',
     handler: async (req, res) => {
       assert.equal(await req.clientId(), 'auth-failed:no-auth');
       res.status(200).json('OK');
@@ -306,6 +313,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-dyn-auth',
+    name: 'testDynAuth',
     scopes: {AllOf: [{for: 'scope', in: 'scopes', each: '<scope>'}]},
     handler: async (req, res) => {
       await req.authorize({scopes: req.body.scopes});
@@ -393,6 +401,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-expression-auth/:provisionerId/:workerType',
+    name: 'testExpAuthWorker',
     scopes: {AllOf: [
       'queue:create-task:<provisionerId>/<workerType>',
       {for: 'route', in: 'routes', each: 'queue:route:<route>'},
@@ -426,6 +435,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-expression-if-then-2',
+    name: 'testIfThen',
     scopes: {if: 'private', then: {AllOf: [
       'some:scope:nobody:has',
     ]}},
@@ -488,6 +498,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-expression-if-then-forget',
+    name: 'testIfThenForget',
     scopes: {AnyOf: [
       'some:scope:nobody:has',
       {if: 'public', then: {AllOf: []}},
@@ -511,6 +522,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-dyn-auth-no-authorize',
+    name: 'testDynNoAuth',
     scopes: {AllOf: [{for: 'scope', in: 'scopes', each: '<scope>'}]},
     handler: async (req, res) => {
       return res.reply({});
@@ -539,6 +551,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-dyn-auth-missing-authorize',
+    name: 'testDynMissingAuth',
     scopes: {AllOf: [{for: 'scope', in: 'scopes', each: '<scope>'}]},
     handler: async (req, res) => {
       await req.authorize({foo: 'bar'});
@@ -568,6 +581,7 @@ suite('api/auth', function() {
   testEndpoint({
     method: 'get',
     route: '/test-bad-auth-side-effects',
+    name: 'testBadAuth',
     scopes: 'something<foo>',
     handlerBuilder: sideEffects => async (req, res) => {
       await req.authorize({foo: 'bar'});

--- a/test/schemaprefix_test.js
+++ b/test/schemaprefix_test.js
@@ -32,7 +32,7 @@ suite('api/schemaPrefix', function() {
   api.declare({
     method:   'get',
     route:    '/test-output',
-    name:     'testInput',
+    name:     'testInputValidOutput',
     output:   'test-schema.json',
     title:    'Test End-Point',
     description:  'Place we can call to test something',

--- a/test/scopes_test.js
+++ b/test/scopes_test.js
@@ -17,7 +17,7 @@ suite('api/route', function() {
     api.declare({
       method:       'get',
       route:        '/test/:myparam',
-      name:         'testEP',
+      name:         'noScopeOktestEP',
       title:        'Test',
       description:  'Test',
     }, function(req, res) {});
@@ -28,7 +28,7 @@ suite('api/route', function() {
       method:       'get',
       route:        '/testString/:myparam',
       scopes:       'test:unit',
-      name:         'testEP',
+      name:         'strScopetestEP',
       title:        'Test',
       description:  'Test',
     }, function(req, res) {});
@@ -40,7 +40,7 @@ suite('api/route', function() {
         method:       'get',
         route:        '/testArr/:myparam',
         scopes:       ['test:unit'],
-        name:         'testEP',
+        name:         'arrayScopeRejectedtestEP',
         title:        'Test',
         description:  'Test',
       }, function(req, res) {});
@@ -53,7 +53,7 @@ suite('api/route', function() {
         method:       'get',
         route:        '/testArrArr/:myparam',
         scopes:       [[]],
-        name:         'testEP',
+        name:         'arrayOfArraytestEP',
         title:        'Test',
         description:  'Test',
       }, function(req, res) {});
@@ -65,7 +65,7 @@ suite('api/route', function() {
       method:       'get',
       route:        '/testScope/:myparam',
       scopes:       {AnyOf: ['something']},
-      name:         'testEP',
+      name:         'expNotRejectedtestEP',
       title:        'Test',
       description:  'Test',
     }, function(req, res) {});
@@ -76,7 +76,7 @@ suite('api/route', function() {
       method:       'get',
       route:        '/testScope2/:myparam',
       scopes:       {AnyOf: [{for: 'foo', in: 'bar', each: '<foo>'}]},
-      name:         'testEP',
+      name:         'expLoopNotRejectedtestEP',
       title:        'Test',
       description:  'Test',
     }, function(req, res) {});

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -17,7 +17,7 @@ suite('api/validate', function() {
   api.declare({
     method:   'post',
     route:    '/test-input',
-    name:     'testInput',
+    name:     'testInputValidate',
     input:    'http://localhost:4321/test-schema.json',
     title:    'Test End-Point',
     description:  'Place we can call to test something',
@@ -29,7 +29,7 @@ suite('api/validate', function() {
   api.declare({
     method:   'get',
     route:    '/test-output',
-    name:     'testInput',
+    name:     'testInputValidOutputValidate',
     output:   'http://localhost:4321/test-schema.json',
     title:    'Test End-Point',
     description:  'Place we can call to test something',
@@ -41,7 +41,7 @@ suite('api/validate', function() {
   api.declare({
     method:   'get',
     route:    '/test-invalid-output',
-    name:     'testInput',
+    name:     'testInputInvalidOutputValidate',
     output:   'http://localhost:4321/test-schema.json',
     title:    'Test End-Point',
     description:  'Place we can call to test something',
@@ -66,7 +66,7 @@ suite('api/validate', function() {
   api.declare({
     method:   'get',
     route:    '/test-skip-output-validation',
-    name:     'testOutputSkipInputValidation',
+    name:     'testOutputSkipOutputValidation',
     output:    'http://localhost:4321/test-schema.json',
     skipOutputValidation: true,
     title:    'Test End-Point',


### PR DESCRIPTION
Reference : BUG 1434583
This would prevent declaration of a method with same name. For now, the tests fail as there are already many test cases with api declarations with same name.
@djmitche Please review and guide me on how to change the tests. Listing in separate files could be a 
solution however not efficient enough. Or else we can rename the duplicate test declarations. After this is fixed I would add the corresponding tests too.
Thank you :D 