### PR TITLE
Use x-forwarded-proto for port detection

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -153,6 +153,8 @@ const remoteAuthentication = ({signatureValidator, entry}) => {
     const port = host.port;
     if (req.headers['x-forwarded-port'] !== undefined) {
       port = parseInt(req.headers['x-forwarded-port'], 10);
+    } else if (req.headers['x-forwarded-proto'] !== undefined) {
+      port = req.headers['x-forwarded-proto'] === 'https' ? 443 : port;
     }
 
     // Send input to signatureValidator (auth server or local validator)


### PR DESCRIPTION
This is useful in gce where the load balancer does not set `x-forwarded-port`