### PR TITLE
Add Cache-Control to the Access-Control-Allow-Headers header

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -178,6 +178,7 @@ const corsHeaders = allowedCORSOrigin => {
       'Authorization',
       'Accept',
       'Origin',
+      'Cache-Control',
     ].join(','));
     next();
   };


### PR DESCRIPTION
The new implementation of tc-events uses an EventSource to
set up communication between the client and server. Attempting
to set up a connection throws an error in the console:
`Request header field Cache-Control is not allowed by
Access-Control-Allow-Headers in preflight response.`.

It turns out you can't set the headers in the EventSource
interface from the client without a polyfill which is non-standard.