### PR TITLE
Bug 1488389 - update taskcluster-lib-scopes in taskcluster-lib-api to include engine requirement fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "promise": "^8.0.1",
     "slugid": "^1.1.0",
     "taskcluster-client": "^10.0.0",
-    "taskcluster-lib-scopes": "^10.0.0",
+    "taskcluster-lib-scopes": "^10.0.1",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,9 +1942,9 @@ taskcluster-lib-monitor@^10.0.0:
     statsum "^0.6.0"
     taskcluster-client "^10.0.0"
 
-taskcluster-lib-scopes@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-10.0.0.tgz#2b90666b8e5127a1d367b726de84c7829b57efef"
+taskcluster-lib-scopes@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-10.0.1.tgz#f3921b2b86e7c09581b045b9b880a4c35fd243e0"
 
 taskcluster-lib-testing@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
It looks like lib-api was missed when the fix for the engine spec landed in lib-scopes, this patch addresses that