### PR TITLE
Pass sourceIp to taskcluster-auth

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -234,7 +234,7 @@ const nonceManager = (options) => {
  * }
  *
  * The function returns takes an object:
- *     {method, resource, host, port, authorization}
+ *     {method, resource, host, port, authorization, sourceIp}
  * And return promise for an object on one of the forms:
  *     {status: 'auth-failed', message},
  *     {status: 'auth-success', scheme, scopes}, or,

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -164,6 +164,7 @@ const remoteAuthentication = ({signatureValidator, entry}) => {
       host:             host.name,
       port:             parseInt(port, 10),
       authorization:    req.headers.authorization,
+      sourceIp:         req.ip,
     }));
 
     // Validate request hash if one is provided


### PR DESCRIPTION
Pass the original source IP of the request to taskcluster-auth so that it can log it within it's auditlog.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1488545
Related: https://github.com/taskcluster/taskcluster-auth/pull/163