### PR TITLE
Bug 1491775 - blob output type in the queue causes a schema validation error

### DIFF
--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -192,7 +192,7 @@
                     },
                     "output": {
                         "type": "string",
-                        "oneOf": [
+                        "anyOf": [
                             {
                                 "title": "Output Schema",
                                 "type": "string",


### PR DESCRIPTION
Using https://www.jsonschemavalidator.net/ shows the more informative error message:

```
Message: JSON is valid against more than one schema from 'oneOf'. Valid schema indexes: 0, 1.
Schema path: #/properties/entries/items/properties/output/oneOf

Message: JSON is valid against more than one schema from 'oneOf'. Valid schema indexes: 0, 1.
Schema path: #/properties/entries/items/properties/output/oneOf
```