### PR TITLE
Bug 1491775 - favour oneOf over anyOf in json schemas for cleaner generated go code

### DIFF
--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -192,10 +192,11 @@
                     },
                     "output": {
                         "type": "string",
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "title": "Output Schema",
                                 "type": "string",
+                                "pattern": "^(?!blob$)",
                                 "description": "JSON schema for output, if output is validated, otherwise not present. The value must be a relative URI, based on the service's schema location; that is, based at `<rootUrl>/schemas/<serviceName`."
                             },
                             {


### PR DESCRIPTION
We generate [this code](https://github.com/taskcluster/taskcluster-client-go/blob/master/codegenerator/model/types.go) from `api-reference.json` for the taskcluster go client. For the coercion of data into structured types, the `oneOf` semantics are easier to deal with than `anyOf`, since with `oneOf` constructions, only one object needs to be populated from the source data. With `anyOf` potentially multiple objects need to be created and evaluated, which can be a little more complex for code that processes the types. For this reason, `oneOf` is usually preferable.

Another option would be to combine the json schemas for `Output Schema` and `Blob` into a single jsonschema with a description that encompasses both options (in this way avoiding `oneOf` and `anyOf` entirely). My personal preference (from favourite to least-favourite) would be:

1) `oneOf` (as per this PR)
2) combining the two schemas into a single schema
3) `anyOf` (as currently implemented)

Thanks for your consideration! :-)