### PR TITLE
Bug 1494677 - (backport) add serviceName and apiVersion to reference

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -635,6 +635,7 @@ var handle = function(handler, context, name) {
  *   title:         "API Title",
  *   description:   "API description in markdown",
  *   schemaPrefix:  "http://schemas..../queue/",    // Prefix for all schemas
+ *   name: serviceName (without `taskcluster-` prefix
  *   params: {                                      // Patterns for URL params
  *     param1:  /.../,                // Reg-exp pattern
  *     param2(val) { return "..." }   // Function, returns message if invalid
@@ -660,6 +661,7 @@ var API = function(options) {
     schemaPrefix:   '',
     params:         {},
     context:        [],
+    apiVersion:     'v1',
     errorCodes:     {},
   });
   _.forEach(this._options.errorCodes, (value, key) => {
@@ -979,7 +981,8 @@ API.prototype.reference = function(options) {
     title:              this._options.title,
     description:        this._options.description,
     baseUrl:            options.baseUrl,
-    name:               this._options.name,
+    serviceName:        this._options.name,
+    apiVersion:         this._options.apiVersion,
     entries: _.concat(this._entries, [ping]).filter(entry => !entry.noPublish).map(function(entry) {
       const [route, params] = cleanRouteAndParams(entry.route);
       var retval = {

--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -66,7 +66,15 @@
     "properties": {
         "version": {
             "description": "API reference version",
-            "const": 0
+            "type": "integer",
+            "enum": [
+                0
+            ]
+        },
+        "apiVersion": {
+            "description": "Version of the API",
+            "type": "string",
+            "pattern": "^v[0-9]+$"
         },
         "$schema": {
             "description": "Link to schema for this reference. That is a link to this very document. Typically used to identify what kind of reference this file is.",
@@ -87,7 +95,7 @@
             "type": "string",
             "format": "uri"
         },
-        "name": {
+        "serviceName": {
             "description": "Name of service for automation. Will be consumed by client generators to produce URLs",
             "type": "string",
             "minLength": 1,
@@ -231,7 +239,8 @@
         "title",
         "description",
         "baseUrl",
-        "name",
-        "entries"
+        "serviceName",
+        "entries",
+        "apiVersion"
     ]
 }


### PR DESCRIPTION
This won't require any additional input from aws-provisioner, just an upgrade (this will probably be v8.4.0)