### PR TITLE
add apiVersion to the list of required properties

### DIFF
--- a/src/schemas/api-reference.json
+++ b/src/schemas/api-reference.json
@@ -244,6 +244,7 @@
         "description",
         "baseUrl",
         "serviceName",
-        "entries"
+        "entries",
+        "apiVersion"
     ]
 }


### PR DESCRIPTION
I noticed this was missing when backporting for aws-provisioner.

I'll upload to S3 and copy to tc-references when merging.