### PR TITLE
Bug 1514042 - include error message in ISE response in non-production

### DIFF
--- a/test/errors_test.js
+++ b/test/errors_test.js
@@ -1,9 +1,10 @@
-const request         = require('superagent');
-const assert          = require('assert');
-const APIBuilder      = require('../');
-const helper          = require('./helper');
-const _               = require('lodash');
-const libUrls         = require('taskcluster-lib-urls');
+const request = require('superagent');
+const assert = require('assert');
+const APIBuilder = require('../');
+const helper = require('./helper');
+const _ = require('lodash');
+const libUrls = require('taskcluster-lib-urls');
+const expressError = require('../src/middleware/express-error.js');
 
 suite('api/errors', function() {
   // Create test api
@@ -20,6 +21,10 @@ suite('api/errors', function() {
     await helper.setupServer({builder});
   });
   teardown(helper.teardownServer);
+
+  // we want to test the production behavior..
+  suiteSetup(function() { expressError.isProduction = true; });
+  suiteTeardown(function() { expressError.isProduction = false; });
 
   builder.declare({
     method:   'get',


### PR DESCRIPTION
Contributors often get hung up when modifying an API method, since the API tests go through HTTP and thus all they see for any error is "Internal Server Error".

This includes the error in the HTTP response, and I have verified in a real service that this appears in the output.  The client does automatically retry the 500 a few times, so the tests "hang" briefly, but I think that's survivable.